### PR TITLE
Marko support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,6 @@ jspm_packages
 
 # vim swap files
 *.swp
+
+# marko generated files
+*.marko.js

--- a/README.md
+++ b/README.md
@@ -17,6 +17,12 @@ In `production` mode, `point-of-view` will heavily cache the templates file and 
 
 *Note that at least Fastify `v0.13.1` is needed.*
 
+#### Benchmarks
+The benchmark were run with the files in the `benchmark` folder with the `ejs` engine.  
+The data has been taken with: `autocannon -c 100 -d 5 -p 10 localhost:3000`
+- Express: 8.8k req/sec
+- **Fastify**: 15.6k req/sec
+
 ## Install
 
 ```

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Currently supports the following templates engines:
 - [`ejs`](http://www.embeddedjs.com/)
 - [`pug`](https://pugjs.org/api/getting-started.html)
 - [`handlebars`](http://handlebarsjs.com/)
+- [`marko`](http://markojs.com/)
 
 In `production` mode, `point-of-view` will heavily cache the templates file and functions, while in `development` will reload every time the template file and function.
 

--- a/benchmark/express.js
+++ b/benchmark/express.js
@@ -1,0 +1,17 @@
+'use strict'
+
+process.env.NODE_ENV = 'production'
+
+const express = require('express')
+const app = express()
+
+app.set('view engine', 'ejs')
+
+app.get('/', (req, res) => {
+  res.render('../../templates/index.ejs', { text: 'text' })
+})
+
+app.listen(3000, err => {
+  if (err) throw err
+  console.log('server listening on 3000')
+})

--- a/benchmark/fastify.js
+++ b/benchmark/fastify.js
@@ -1,0 +1,20 @@
+'use strict'
+
+process.env.NODE_ENV = 'production'
+
+const fastify = require('fastify')()
+
+fastify.register(require('../index'), {
+  engine: {
+    ejs: require('ejs')
+  }
+})
+
+fastify.get('/', (req, reply) => {
+  reply.view('../templates/index.ejs', { text: 'text' })
+})
+
+fastify.listen(3000, err => {
+  if (err) throw err
+  console.log(`server listening on ${fastify.server.address().port}`)
+})

--- a/index.js
+++ b/index.js
@@ -60,19 +60,7 @@ function fastifyView (fastify, opts, next) {
       return
     }
 
-    const markoTemplate = lru.get(page)
-
-    if (markoTemplate && prod) {
-      if (opts && opts.stream) {
-        this.send(markoTemplate.stream(data))
-      } else {
-        markoTemplate.renderToString(data, send(this))
-      }
-      return
-    }
-
     const template = engine.load(join(templatesDir, page))
-    lru.set(page, template)
 
     if (opts && opts.stream) {
       this.send(template.stream(data))

--- a/index.js
+++ b/index.js
@@ -1,14 +1,12 @@
 'use strict'
 
 const fp = require('fastify-plugin')
-const fs = require('fs')
-const path = require('path')
+const readFile = require('fs').readFile
+const join = require('path').join
 const HLRU = require('hashlru')
-const supportedEngines = ['ejs', 'pug', 'handlebars']
+const supportedEngines = ['ejs', 'pug', 'handlebars', 'marko']
 
 function fastifyView (fastify, opts, next) {
-  fastify.decorateReply('view', view)
-
   if (!opts.engine) {
     next(new Error('Missing engine'))
     return
@@ -22,9 +20,11 @@ function fastifyView (fastify, opts, next) {
 
   const engine = opts.engine[type]
   const options = opts.options || {}
-  const templatesDir = path.join(process.cwd(), opts.templates || './')
+  const templatesDir = join(process.cwd(), opts.templates || './')
   const lru = HLRU(opts.maxCache || 100)
   const prod = process.env.NODE_ENV === 'production'
+
+  fastify.decorateReply('view', type === 'marko' ? viewMarko : view)
 
   function view (page, data) {
     if (!page || !data) {
@@ -39,7 +39,7 @@ function fastifyView (fastify, opts, next) {
       return
     }
 
-    fs.readFile(path.join(templatesDir, page), 'utf8', readCallback(this, page, data))
+    readFile(join(templatesDir, page), 'utf8', readCallback(this, page, data))
   }
 
   function readCallback (that, page, data) {
@@ -51,6 +51,40 @@ function fastifyView (fastify, opts, next) {
 
       lru.set(page, engine.compile(html, options))
       that.header('Content-Type', 'text/html').send(lru.get(page)(data))
+    }
+  }
+
+  function viewMarko (page, data, opts) {
+    if (!page || !data) {
+      this.send(new Error('Missing data'))
+      return
+    }
+
+    const markoTemplate = lru.get(page)
+
+    if (markoTemplate && prod) {
+      if (opts && opts.stream) {
+        this.send(markoTemplate.stream(data))
+      } else {
+        markoTemplate.renderToString(data, send(this))
+      }
+      return
+    }
+
+    const template = engine.load(join(templatesDir, page))
+    lru.set(page, template)
+
+    if (opts && opts.stream) {
+      this.send(template.stream(data))
+    } else {
+      template.renderToString(data, send(this))
+    }
+
+    function send (that) {
+      return function _send (err, html) {
+        if (err) return that.send(err)
+        that.header('Content-Type', 'text/html').send(html)
+      }
     }
   }
 

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
   },
   "devDependencies": {
     "ejs": "^2.5.6",
+    "express": "^4.15.2",
     "fastify": "^0.13.1",
     "handlebars": "^4.0.6",
     "marko": "^4.2.2",

--- a/package.json
+++ b/package.json
@@ -33,10 +33,16 @@
     "ejs": "^2.5.6",
     "fastify": "^0.13.1",
     "handlebars": "^4.0.6",
+    "marko": "^4.2.2",
     "pre-commit": "^1.2.2",
     "pug": "^2.0.0-beta11",
     "request": "^2.81.0",
     "standard": "^9.0.2",
     "tap": "^10.3.0"
+  },
+  "standard": {
+    "ignore": [
+      "*.marko.js"
+    ]
   }
 }

--- a/templates/index.marko
+++ b/templates/index.marko
@@ -1,0 +1,7 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head></head>
+  <body>
+    <p>${input.text}</p>
+  </body>
+</html>

--- a/test.js
+++ b/test.js
@@ -221,3 +221,68 @@ test('reply.view with handlebars engine', t => {
     })
   })
 })
+
+test('reply.view with marko engine', t => {
+  t.plan(6)
+  const fastify = Fastify()
+  const marko = require('marko')
+  const data = { text: 'text' }
+
+  fastify.register(require('./index'), {
+    engine: {
+      marko: marko
+    }
+  })
+
+  fastify.get('/', (req, reply) => {
+    reply.view('/templates/index.marko', data)
+  })
+
+  fastify.listen(0, err => {
+    t.error(err)
+
+    request({
+      method: 'GET',
+      uri: 'http://localhost:' + fastify.server.address().port
+    }, (err, response, body) => {
+      t.error(err)
+      t.strictEqual(response.statusCode, 200)
+      t.strictEqual(response.headers['content-length'], '' + body.length)
+      t.strictEqual(response.headers['content-type'], 'text/html')
+      t.strictEqual(marko.load('./templates/index.marko').renderToString(data), body)
+      fastify.close()
+    })
+  })
+})
+
+test('reply.view with marko engine, with stream', t => {
+  t.plan(5)
+  const fastify = Fastify()
+  const marko = require('marko')
+  const data = { text: 'text' }
+
+  fastify.register(require('./index'), {
+    engine: {
+      marko: marko
+    }
+  })
+
+  fastify.get('/', (req, reply) => {
+    reply.view('/templates/index.marko', data, { stream: true })
+  })
+
+  fastify.listen(0, err => {
+    t.error(err)
+
+    request({
+      method: 'GET',
+      uri: 'http://localhost:' + fastify.server.address().port
+    }, (err, response, body) => {
+      t.error(err)
+      t.strictEqual(response.statusCode, 200)
+      t.strictEqual(response.headers['content-type'], 'application/octet-stream')
+      t.strictEqual(marko.load('./templates/index.marko').renderToString(data), body)
+      fastify.close()
+    })
+  })
+})


### PR DESCRIPTION
As titled.
The benchmark are very promising, with `Marko` we gain at least 1000 request per second compared to `ejs` :)

Feedbacks?
cc @mcollina @jsumners @patrick-steele-idem