### PR TITLE
Pass templatesDir to nunjucks to let extends work.

### DIFF
--- a/index.js
+++ b/index.js
@@ -106,15 +106,9 @@ function fastifyView (fastify, opts, next) {
       this.send(new Error('Missing data'))
       return
     }
-    // Create nunjucks environment with custom options.
-    // Do not pass templatesDir to nunjucks.configure(),
-    // otherwise all nunjucks function will take templatesDir as their
-    // path, and will cause error in test.
-    const env = engine.configure(options)
-    // append view extension
+    const env = engine.configure(templatesDir, options)
+    // Append view extension.
     page = getPage(page, 'njk')
-    // Use path.join() to dealing with path like '/index.njk'.
-    // This will let it find the correct template path.
     env.render(join(templatesDir, page), data, (err, html) => {
       if (err) return this.send(err)
       this.header('Content-Type', 'text/html').send(html)

--- a/test.js
+++ b/test.js
@@ -419,7 +419,8 @@ test('reply.view with nunjucks engine and custom templates folder', t => {
       t.strictEqual(response.statusCode, 200)
       t.strictEqual(response.headers['content-length'], '' + body.length)
       t.strictEqual(response.headers['content-type'], 'text/html')
-      t.strictEqual(nunjucks.render('./templates/index.njk', data), body)
+      // Global Nunjucks templates dir changed here.
+      t.strictEqual(nunjucks.render('./index.njk', data), body)
       fastify.close()
     })
   })
@@ -453,13 +454,14 @@ test('reply.view with nunjucks engine and full path templates folder', t => {
       t.strictEqual(response.statusCode, 200)
       t.strictEqual(response.headers['content-length'], '' + body.length)
       t.strictEqual(response.headers['content-type'], 'text/html')
-      t.strictEqual(nunjucks.render('./templates/index.njk', data), body)
+      // Global Nunjucks templates dir changed here.
+      t.strictEqual(nunjucks.render('./index.njk', data), body)
       fastify.close()
     })
   })
 })
 
-test('reply.view with nunjucks engine', t => {
+test('reply.view with nunjucks engine and includeViewExtension is true', t => {
   t.plan(6)
   const fastify = Fastify()
   const nunjucks = require('nunjucks')
@@ -468,11 +470,12 @@ test('reply.view with nunjucks engine', t => {
   fastify.register(require('./index'), {
     engine: {
       nunjucks: nunjucks
-    }
+    },
+    includeViewExtension: true
   })
 
   fastify.get('/', (req, reply) => {
-    reply.view('/templates/index.njk', data)
+    reply.view('/templates/index', data)
   })
 
   fastify.listen(0, err => {
@@ -486,6 +489,7 @@ test('reply.view with nunjucks engine', t => {
       t.strictEqual(response.statusCode, 200)
       t.strictEqual(response.headers['content-length'], '' + body.length)
       t.strictEqual(response.headers['content-type'], 'text/html')
+      // Global Nunjucks templates dir is  `./` here.
       t.strictEqual(nunjucks.render('./templates/index.njk', data), body)
       fastify.close()
     })


### PR DESCRIPTION
I find that in my old code if I use nunjucks' extends tag it will give a error because template path not given so I added it and fixed wrong test case.