### PR TITLE
issue38, update dependencies for nunjucks and others

### DIFF
--- a/example-ejs-with-some-options.js
+++ b/example-ejs-with-some-options.js
@@ -14,7 +14,7 @@ fastify.register(require('./index'), {
   options: {
     filename: resolve(templatesFolder)
   },
-  charset: 'utf-8'  // sample usage, but specifying the same value already used as default
+  charset: 'utf-8' // sample usage, but specifying the same value already used as default
 })
 
 fastify.get('/', (req, reply) => {

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   },
   "homepage": "https://github.com/fastify/point-of-view#readme",
   "dependencies": {
-    "fastify-plugin": "^0.2.1",
+    "fastify-plugin": "^0.2.2",
     "hashlru": "^2.2.1"
   },
   "devDependencies": {
@@ -38,15 +38,15 @@
     "ejs": "^2.5.7",
     "ejs-mate": "^2.3.0",
     "express": "^4.16.2",
-    "fastify": "^0.41.0",
+    "fastify": "^0.43.0",
     "handlebars": "^4.0.11",
     "marko": "^4.7.5",
-    "nunjucks": "^3.0.1",
+    "nunjucks": "^3.1.0",
     "pre-commit": "^1.2.2",
     "pug": "^2.0.0-rc.4",
     "request": "^2.83.0",
-    "standard": "^10.0.3",
-    "tap": "^11.0.1"
+    "standard": "^11.0.0",
+    "tap": "^11.1.1"
   },
   "standard": {
     "ignore": [

--- a/test-with-snapshot.js
+++ b/test-with-snapshot.js
@@ -12,8 +12,8 @@ test('reply.view with ejs engine, template folder specified, include files (ejs 
   const resolve = require('path').resolve
   const templatesFolder = 'templates'
   const options = {
-    filename: resolve(templatesFolder),  // needed for include files to be resolved in include directive ...
-    views: [__dirname]  // must be put to make tests (with include files) working ...
+    filename: resolve(templatesFolder), // needed for include files to be resolved in include directive ...
+    views: [__dirname] // must be put to make tests (with include files) working ...
   }
   const data = { text: 'text' }
 
@@ -27,7 +27,7 @@ test('reply.view with ejs engine, template folder specified, include files (ejs 
   })
 
   fastify.get('/', (req, reply) => {
-    reply.type('text/html; charset=utf-8').view('index-linking-other-pages', data)  // sample for specifying with type
+    reply.type('text/html; charset=utf-8').view('index-linking-other-pages', data) // sample for specifying with type
     // reply.view('index-linking-other-pages', data)
   })
 
@@ -196,7 +196,7 @@ test('reply.view with ejs engine, templates with folder specified, include files
       let content = null
       ejs.renderFile(templatesFolder + '/index-with-includes-one-missing.ejs', data, options, function (err, str) {
         content = str
-        t.type(err, Error)  // expected Error here ...
+        t.type(err, Error) // expected Error here ...
         t.strictEqual(content, undefined)
       })
       t.matchSnapshot(content, 'output')
@@ -246,7 +246,7 @@ test('reply.view with ejs engine, templates with folder specified, include files
       let content = null
       ejs.renderFile(templatesFolder + '/index-with-includes-and-attribute-missing.ejs', data, options, function (err, str) {
         content = str
-        t.type(err, Error)  // expected Error here ...
+        t.type(err, Error) // expected Error here ...
         t.strictEqual(content, undefined)
       })
       t.matchSnapshot(content, 'output')

--- a/test.js
+++ b/test.js
@@ -537,8 +537,8 @@ test('reply.view with ejs engine, template folder specified, include files (ejs 
   const resolve = require('path').resolve
   const templatesFolder = 'templates'
   const options = {
-    filename: resolve(templatesFolder),  // needed for include files to be resolved in include directive ...
-    views: [__dirname]  // must be put to make tests (with include files) working ...
+    filename: resolve(templatesFolder), // needed for include files to be resolved in include directive ...
+    views: [__dirname] // must be put to make tests (with include files) working ...
   }
   const data = { text: 'text' }
 
@@ -552,7 +552,7 @@ test('reply.view with ejs engine, template folder specified, include files (ejs 
   })
 
   fastify.get('/', (req, reply) => {
-    reply.type('text/html; charset=utf-8').view('index-linking-other-pages', data)  // sample for specifying with type
+    reply.type('text/html; charset=utf-8').view('index-linking-other-pages', data) // sample for specifying with type
     // reply.view('index-with-includes', data)
   })
 
@@ -718,7 +718,7 @@ test('reply.view with ejs engine, templates with folder specified, include files
       let content = null
       ejs.renderFile(templatesFolder + '/index-with-includes-one-missing.ejs', data, options, function (err, str) {
         content = str
-        t.type(err, Error)  // expected Error here ...
+        t.type(err, Error) // expected Error here ...
         t.strictEqual(content, undefined)
       })
 
@@ -767,7 +767,7 @@ test('reply.view with ejs engine, templates with folder specified, include files
       let content = null
       ejs.renderFile(templatesFolder + '/index-with-includes-and-attribute-missing.ejs', data, options, function (err, str) {
         content = str
-        t.type(err, Error)  // expected Error here ...
+        t.type(err, Error) // expected Error here ...
         t.strictEqual(content, undefined)
       })
 


### PR DESCRIPTION
Updated dependencies for nunjucks and other packages, and update sources to new (stricter) rules of 'standard'.

@mcollina Matteo sorry for now I just stay on last Fastify 0.x (0.43.0), is it good the same ?
Last, in this PR should I update plugin release too (for example to '0.8.0') ?

Thanks a lot,
Sandro