### PR TITLE
Allow templates to be rendered without reply

### DIFF
--- a/index.js
+++ b/index.js
@@ -34,6 +34,7 @@ function fastifyView (fastify, opts, next) {
     _default: view
   }
 
+  fastify.decorate('view', renders[type] ? renders[type] : renders._default)
   fastify.decorateReply('view', renders[type] ? renders[type] : renders._default)
 
   function getPage (page, extension) {

--- a/test.js
+++ b/test.js
@@ -7,6 +7,24 @@ const Fastify = require('fastify')
 const fs = require('fs')
 const path = require('path')
 
+test('fastify.view exist', t => {
+  t.plan(2)
+  const fastify = Fastify()
+
+  fastify.register(require('./index'), {
+    engine: {
+      ejs: require('ejs')
+    }
+  })
+
+  fastify.ready(err => {
+    t.error(err)
+    t.ok(fastify.view)
+
+    fastify.close()
+  })
+})
+
 test('reply.view exist', t => {
   t.plan(6)
   const fastify = Fastify()


### PR DESCRIPTION
Something you'll need to render a template without a "reply" context. Like a notification email for example. This PR adds `fastify.view()` just for that. 