### PR TITLE
Fix for production view cache issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,14 @@ const minifierOpts = {
   }
 ```
 
+The optional boolean property `production` will override environment variable `NODE_ENV` and force `point-of-view` into `production` or `development` mode:
+```js
+  options: {
+    // force production mode
+    production: true
+  }
+```
+
 <a name="note"></a>
 ## Note
 

--- a/index.js
+++ b/index.js
@@ -25,7 +25,7 @@ function fastifyView (fastify, opts, next) {
   const templatesDir = resolve(opts.templates || './')
   const lru = HLRU(opts.maxCache || 100)
   const includeViewExtension = opts.includeViewExtension || false
-  const prod = opts.prod || process.env.NODE_ENV === 'production'
+  const prod = typeof opts.production === 'boolean' ? opts.production : process.env.NODE_ENV === 'production'
   const renders = {
     marko: viewMarko,
     'ejs-mate': viewEjsMate,

--- a/index.js
+++ b/index.js
@@ -25,7 +25,7 @@ function fastifyView (fastify, opts, next) {
   const templatesDir = resolve(opts.templates || './')
   const lru = HLRU(opts.maxCache || 100)
   const includeViewExtension = opts.includeViewExtension || false
-  const prod = process.env.NODE_ENV === 'production'
+  const prod = opts.prod || process.env.NODE_ENV === 'production'
   const renders = {
     marko: viewMarko,
     'ejs-mate': viewEjsMate,

--- a/index.js
+++ b/index.js
@@ -176,7 +176,7 @@ function fastifyView (fastify, opts, next) {
     const toHtml = lru.get(page)
 
     if (toHtml && prod) {
-      if (!this.res.getHeader('content-type')) {
+      if (!this.getHeader('content-type')) {
         this.header('Content-Type', 'text/html; charset=' + charset)
       }
       this.send(toHtml(data))
@@ -274,7 +274,7 @@ function fastifyView (fastify, opts, next) {
     const toHtml = lru.get(page)
 
     if (toHtml && prod) {
-      if (!this.res.getHeader('content-type')) {
+      if (!this.getHeader('content-type')) {
         this.header('Content-Type', 'text/html; charset=' + charset)
       }
       this.send(toHtml(data))

--- a/test.js
+++ b/test.js
@@ -1615,3 +1615,69 @@ test('reply.view with handlebars engine and includeViewExtension property as tru
     })
   })
 })
+
+test('fastify.view with ejs engine and callback in production mode', t => {
+  t.plan(6)
+  const fastify = Fastify()
+  const ejs = require('ejs')
+  const data = { text: 'text' }
+
+  fastify.register(require('./index'), {
+    engine: {
+      ejs: ejs
+    },
+    prod: true
+  })
+
+  fastify.ready(err => {
+    t.error(err)
+
+    fastify.view('/templates/index.ejs', data, (err, compiled) => {
+      t.error(err)
+      t.strictEqual(ejs.render(fs.readFileSync('./templates/index.ejs', 'utf8'), data), compiled)
+
+      fastify.ready(err => {
+        t.error(err)
+
+        fastify.view('/templates/index.ejs', data, (err, compiled) => {
+          t.error(err)
+          t.strictEqual(ejs.render(fs.readFileSync('./templates/index.ejs', 'utf8'), data), compiled)
+          fastify.close()
+        })
+      })
+    })
+  })
+})
+
+test('fastify.view with handlebars engine and callback in production mode', t => {
+  t.plan(6)
+  const fastify = Fastify()
+  const handlebars = require('handlebars')
+  const data = { text: 'text' }
+
+  fastify.register(require('./index'), {
+    engine: {
+      handlebars: handlebars
+    },
+    prod: true
+  })
+
+  fastify.ready(err => {
+    t.error(err)
+
+    fastify.view('/templates/index.html', data, (err, compiled) => {
+      t.error(err)
+      t.strictEqual(handlebars.compile(fs.readFileSync('./templates/index.html', 'utf8'))(data), compiled)
+
+      fastify.ready(err => {
+        t.error(err)
+
+        fastify.view('/templates/index.html', data, (err, compiled) => {
+          t.error(err)
+          t.strictEqual(handlebars.compile(fs.readFileSync('./templates/index.html', 'utf8'))(data), compiled)
+          fastify.close()
+        })
+      })
+    })
+  })
+})

--- a/test.js
+++ b/test.js
@@ -1626,7 +1626,7 @@ test('fastify.view with ejs engine and callback in production mode', t => {
     engine: {
       ejs: ejs
     },
-    prod: true
+    production: true
   })
 
   fastify.ready(err => {
@@ -1659,7 +1659,7 @@ test('fastify.view with handlebars engine and callback in production mode', t =>
     engine: {
       handlebars: handlebars
     },
-    prod: true
+    production: true
   })
 
   fastify.ready(err => {


### PR DESCRIPTION
I am currently staging a project for production that uses this plugin and ran into this bug.

It seems to only affect `fastify.view()` and not `reply.view()`. I stumbled upon it through the approach of supporting async/await mentioned here https://github.com/fastify/point-of-view/issues/87#issuecomment-465327052.

Regarding testing, I had to add an option to force the plugin into production mode. The tests were setup to fail and then clear as soon as the bug was fixed.