### PR TITLE
Fixes chaining in rendering

### DIFF
--- a/index.js
+++ b/index.js
@@ -212,7 +212,8 @@ function fastifyView (fastify, opts, next) {
       if (options.useHtmlMinifier && (typeof options.useHtmlMinifier.minify === 'function')) {
         html = options.useHtmlMinifier.minify(html, options.htmlMinifierOptions || {})
       }
-      this.header('Content-Type', 'text/html; charset=' + charset).send(html)
+      this.header('Content-Type', 'text/html; charset=' + charset)
+      this.send(html)
     })
   }
 
@@ -241,7 +242,8 @@ function fastifyView (fastify, opts, next) {
 
     try {
       const html = render(page, data)
-      this.header('Content-Type', 'text/html; charset=' + charset).send(html)
+      this.header('Content-Type', 'text/html; charset=' + charset)
+      this.send(html)
     } catch (error) {
       this.send(error)
     }
@@ -264,7 +266,8 @@ function fastifyView (fastify, opts, next) {
       if (options.useHtmlMinifier && (typeof options.useHtmlMinifier.minify === 'function')) {
         html = options.useHtmlMinifier.minify(html, options.htmlMinifierOptions || {})
       }
-      this.header('Content-Type', 'text/html; charset=' + charset).send(html)
+      this.header('Content-Type', 'text/html; charset=' + charset)
+      this.send(html)
     })
   }
 


### PR DESCRIPTION
Due to the following code, chaining header and send will not work. Removing the chaining fixes the problem.

```js
 const promise = new Promise((resolve, reject) => {
      renderer.apply({
        getHeader: () => {},
        header: () => {},
        send: result => {
          if (result instanceof Error) {
            reject(result)
            return
          }

          resolve(result)
        }
      }, args)
    })
```