### PR TITLE
Fix relative include for Pug

### DIFF
--- a/index.js
+++ b/index.js
@@ -145,6 +145,7 @@ function fastifyView (fastify, opts, next) {
 
       let compiledPage
       try {
+        options.filename = options.filename || join(templatesDir, page)
         compiledPage = engine.compile(html, options)
       } catch (error) {
         that.send(error)

--- a/index.js
+++ b/index.js
@@ -145,7 +145,7 @@ function fastifyView (fastify, opts, next) {
 
       let compiledPage
       try {
-        options.filename = options.filename || join(templatesDir, page)
+        options.filename = join(templatesDir, page)
         compiledPage = engine.compile(html, options)
       } catch (error) {
         that.send(error)

--- a/templates/layout.pug
+++ b/templates/layout.pug
@@ -1,0 +1,5 @@
+doctype html
+html
+  head
+  body
+    block content

--- a/templates/sample.pug
+++ b/templates/sample.pug
@@ -1,0 +1,4 @@
+extends layout
+
+block content
+  p #{text}

--- a/test/test-pug.js
+++ b/test/test-pug.js
@@ -48,6 +48,39 @@ test('reply.view with pug engine', t => {
   })
 })
 
+test('reply.view with pug engine and includes', t => {
+  t.plan(6)
+  const fastify = Fastify()
+  const pug = require('pug')
+  const data = { text: 'text', filename: './templates/sample.pug' }
+
+  fastify.register(require('../index'), {
+    engine: {
+      pug: pug
+    }
+  })
+
+  fastify.get('/', (req, reply) => {
+    reply.view('./templates/sample.pug', data)
+  })
+
+  fastify.listen(0, err => {
+    t.error(err)
+
+    sget({
+      method: 'GET',
+      url: 'http://localhost:' + fastify.server.address().port
+    }, (err, response, body) => {
+      t.error(err)
+      t.strictEqual(response.statusCode, 200)
+      t.strictEqual(response.headers['content-length'], '' + body.length)
+      t.strictEqual(response.headers['content-type'], 'text/html; charset=utf-8')
+      t.strictEqual(pug.render(fs.readFileSync('./templates/sample.pug', 'utf8'), data), body.toString())
+      fastify.close()
+    })
+  })
+})
+
 test('reply.view with pug engine and defaultContext', t => {
   t.plan(6)
   const fastify = Fastify()

--- a/test/test-pug.js
+++ b/test/test-pug.js
@@ -52,7 +52,7 @@ test('reply.view with pug engine and includes', t => {
   t.plan(6)
   const fastify = Fastify()
   const pug = require('pug')
-  const data = { text: 'text', filename: './templates/sample.pug' }
+  const data = { text: 'text' }
 
   fastify.register(require('../index'), {
     engine: {
@@ -75,7 +75,7 @@ test('reply.view with pug engine and includes', t => {
       t.strictEqual(response.statusCode, 200)
       t.strictEqual(response.headers['content-length'], '' + body.length)
       t.strictEqual(response.headers['content-type'], 'text/html; charset=utf-8')
-      t.strictEqual(pug.render(fs.readFileSync('./templates/sample.pug', 'utf8'), data), body.toString())
+      t.strictEqual(pug.renderFile('./templates/sample.pug', data), body.toString())
       fastify.close()
     })
   })


### PR DESCRIPTION
#### Description

Currently, relative includes using Pug are not working.
To reproduce, let's create two templates and the configuration:

```pug
//- templates/layout.pug
doctype html
html(lang='en')
  head
    meta(charset='utf-8')
    title= title
  body
    block content
```

```pug
//- templates/index.pug
extends layout
block content
  h1= title
  h2 Welcome to #{title}!
```

```js
// app.js
fastify.register(require('point-of-view'), {
  engines: {
    pug: require('pug'),
  },
  templates: 'templates',
  includeViewExtension: true,
})

fastify.get('/', (response, reply) => {
  reply.view('index', { title: 'Fastify' })
})
```

For now, it just throws telling that you should [provide a `filename` option](https://pugjs.org/api/reference.html#options) when rendering in order for Pug to resolve the relative include (`basedir` is needed for absolute include).
Also, providing `options.filename` like recommended for EJS doesn't work at all (needs a subdirectory and it's not portable if you have templates inside folders).

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
