### PR TITLE
Make data-parameter of view(page, data) optional

### DIFF
--- a/index.js
+++ b/index.js
@@ -192,10 +192,11 @@ function fastifyView (fastify, opts, next) {
   }
 
   function viewEjsMate (page, data) {
-    if (!page || !data) {
+    if (!page) {
       this.send(new Error('Missing data'))
       return
     }
+
     data = Object.assign({}, defaultCtx, data)
     const confs = Object.assign({}, options)
     if (!confs.settings) {
@@ -217,7 +218,7 @@ function fastifyView (fastify, opts, next) {
   }
 
   function viewArtTemplate (page, data) {
-    if (!page || !data) {
+    if (!page) {
       this.send(new Error('Missing data'))
       return
     }
@@ -248,7 +249,7 @@ function fastifyView (fastify, opts, next) {
   }
 
   function viewNunjucks (page, data) {
-    if (!page || !data) {
+    if (!page) {
       this.send(new Error('Missing data'))
       return
     }
@@ -269,7 +270,7 @@ function fastifyView (fastify, opts, next) {
   }
 
   function viewMarko (page, data, opts) {
-    if (!page || !data) {
+    if (!page) {
       this.send(new Error('Missing data'))
       return
     }
@@ -302,7 +303,7 @@ function fastifyView (fastify, opts, next) {
   }
 
   function viewHandlebars (page, data) {
-    if (!page || !data) {
+    if (!page) {
       this.send(new Error('Missing data'))
       return
     }
@@ -339,7 +340,7 @@ function fastifyView (fastify, opts, next) {
   }
 
   function viewMustache (page, data, opts) {
-    if (!page || !data) {
+    if (!page) {
       this.send(new Error('Missing data'))
       return
     }

--- a/index.js
+++ b/index.js
@@ -220,7 +220,7 @@ function fastifyView (fastify, opts, next) {
 
   function viewArtTemplate (page, data) {
     if (!page) {
-      this.send(new Error('Missing data'))
+      this.send(new Error('Missing page'))
       return
     }
     data = Object.assign({}, defaultCtx, data)
@@ -254,7 +254,7 @@ function fastifyView (fastify, opts, next) {
 
   function viewNunjucks (page, data) {
     if (!page) {
-      this.send(new Error('Missing data'))
+      this.send(new Error('Missing page'))
       return
     }
     const env = engine.configure(templatesDir, options)
@@ -275,7 +275,7 @@ function fastifyView (fastify, opts, next) {
 
   function viewMarko (page, data, opts) {
     if (!page) {
-      this.send(new Error('Missing data'))
+      this.send(new Error('Missing page'))
       return
     }
 
@@ -308,7 +308,7 @@ function fastifyView (fastify, opts, next) {
 
   function viewHandlebars (page, data) {
     if (!page) {
-      this.send(new Error('Missing data'))
+      this.send(new Error('Missing page'))
       return
     }
 
@@ -345,7 +345,7 @@ function fastifyView (fastify, opts, next) {
 
   function viewMustache (page, data, opts) {
     if (!page) {
-      this.send(new Error('Missing data'))
+      this.send(new Error('Missing page'))
       return
     }
 

--- a/templates/index-bare.html
+++ b/templates/index-bare.html
@@ -1,0 +1,1 @@
+<!DOCTYPE html><html lang="en"><head></head><body><p></p><br/></body></html>

--- a/templates/index-bare.html
+++ b/templates/index-bare.html
@@ -1,1 +1,1 @@
-<!DOCTYPE html><html lang="en"><head></head><body><p></p><br/></body></html>
+<!DOCTYPE html><html lang="en"><head></head><body><p>test</p><br/></body></html>

--- a/test/test-art-template.js
+++ b/test/test-art-template.js
@@ -43,7 +43,43 @@ test('reply.view with art-template engine and custom templates folder', t => {
   })
 })
 
-test('reply.view for art-template without data-parameter', t => {
+test('reply.view for art-template without data-parameter and defaultContext', t => {
+  t.plan(6)
+  const fastify = Fastify()
+  const art = require('art-template')
+
+  fastify.register(require('../index'), {
+    engine: {
+      'art-template': art
+    },
+    templates: 'templates'
+  })
+
+  fastify.get('/', (req, reply) => {
+    reply.view('./index.art')
+  })
+
+  fastify.listen(10086, err => {
+    t.error(err)
+
+    sget({
+      method: 'GET',
+      url: 'http://127.0.0.1:10086/'
+    }, (err, response, body) => {
+      t.error(err)
+      t.strictEqual(response.statusCode, 200)
+      t.strictEqual(response.headers['content-length'], '' + body.length)
+      t.strictEqual(response.headers['content-type'], 'text/html; charset=utf-8')
+
+      const templatePath = path.join(__dirname, '..', 'templates', 'index.art')
+
+      t.strictEqual(art(templatePath, {}), body.toString())
+      fastify.close()
+    })
+  })
+})
+
+test('reply.view for art-template without data-parameter but with defaultContext', t => {
   t.plan(6)
   const fastify = Fastify()
   const art = require('art-template')

--- a/test/test-art-template.js
+++ b/test/test-art-template.js
@@ -43,6 +43,44 @@ test('reply.view with art-template engine and custom templates folder', t => {
   })
 })
 
+test('reply.view for art-template without data-parameter', t => {
+  t.plan(6)
+  const fastify = Fastify()
+  const art = require('art-template')
+  const data = { text: 'text' }
+
+  fastify.register(require('../index'), {
+    engine: {
+      'art-template': art
+    },
+    defaultContext: data,
+    templates: 'templates'
+  })
+
+  fastify.get('/', (req, reply) => {
+    reply.view('./index.art')
+  })
+
+  fastify.listen(10086, err => {
+    t.error(err)
+
+    sget({
+      method: 'GET',
+      url: 'http://127.0.0.1:10086/'
+    }, (err, response, body) => {
+      t.error(err)
+      t.strictEqual(response.statusCode, 200)
+      t.strictEqual(response.headers['content-length'], '' + body.length)
+      t.strictEqual(response.headers['content-type'], 'text/html; charset=utf-8')
+
+      const templatePath = path.join(__dirname, '..', 'templates', 'index.art')
+
+      t.strictEqual(art(templatePath, data), body.toString())
+      fastify.close()
+    })
+  })
+})
+
 test('reply.view with art-template engine and defaultContext', t => {
   t.plan(6)
   const fastify = Fastify()

--- a/test/test-ejs-mate.js
+++ b/test/test-ejs-mate.js
@@ -1,7 +1,6 @@
 'use strict'
 
 const t = require('tap')
-const fs = require('fs')
 const test = t.test
 const sget = require('simple-get').concat
 const Fastify = require('fastify')
@@ -42,7 +41,7 @@ test('reply.view with ejs-mate engine', t => {
       t.strictEqual(response.statusCode, 200)
       t.strictEqual(response.headers['content-length'], '' + body.length)
       t.strictEqual(response.headers['content-type'], 'text/html; charset=utf-8')
-      t.strictEqual('<html><head></head><body><h1>header</h1><div>text</div><div>footer</div></body></html>', body.toString())
+      t.strictEqual(body.toString(), '<html><head></head><body><h1>header</h1><div>text</div><div>footer</div></body></html>')
       fastify.close()
     })
   })
@@ -86,7 +85,6 @@ test('reply.view for ejs-mate engine without data and without defaultContext', t
   t.plan(6)
   const fastify = Fastify()
   const ejsMate = require('ejs-mate')
-  const indexContent = fs.readFileSync('./templates/index-bare.html', 'utf-8')
 
   fastify.register(require('../index'), {
     engine: {
@@ -109,7 +107,7 @@ test('reply.view for ejs-mate engine without data and without defaultContext', t
       t.strictEqual(response.statusCode, 200)
       t.strictEqual(response.headers['content-length'], '' + body.length)
       t.strictEqual(response.headers['content-type'], 'text/html; charset=utf-8')
-      t.strictEqual(indexContent, body.toString())
+      t.strictEqual(body.toString(), '<!DOCTYPE html><html lang="en"><head></head><body><p>test</p><br/></body></html>')
       fastify.close()
     })
   })

--- a/test/test-ejs-mate.js
+++ b/test/test-ejs-mate.js
@@ -47,6 +47,40 @@ test('reply.view with ejs-mate engine', t => {
   })
 })
 
+test('reply.view for ejs-mate engine without data-parameter', t => {
+  t.plan(6)
+  const fastify = Fastify()
+  const ejsMate = require('ejs-mate')
+  const data = { text: 'text', header: 'header', footer: 'footer' }
+
+  fastify.register(require('../index'), {
+    engine: {
+      'ejs-mate': ejsMate
+    },
+    defaultContext: data
+  })
+
+  fastify.get('/', (req, reply) => {
+    reply.view('./templates/content.ejs')
+  })
+
+  fastify.listen(0, err => {
+    t.error(err)
+
+    sget({
+      method: 'GET',
+      url: 'http://localhost:' + fastify.server.address().port
+    }, (err, response, body) => {
+      t.error(err)
+      t.strictEqual(response.statusCode, 200)
+      t.strictEqual(response.headers['content-length'], '' + body.length)
+      t.strictEqual(response.headers['content-type'], 'text/html; charset=utf-8')
+      t.strictEqual('<html><head></head><body><h1>header</h1><div>text</div><div>footer</div></body></html>', body.toString())
+      fastify.close()
+    })
+  })
+})
+
 test('reply.view with ejs-mate engine and defaultContext', t => {
   t.plan(6)
   const fastify = Fastify()

--- a/test/test-ejs-mate.js
+++ b/test/test-ejs-mate.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const t = require('tap')
+const fs = require('fs')
 const test = t.test
 const sget = require('simple-get').concat
 const Fastify = require('fastify')
@@ -47,7 +48,7 @@ test('reply.view with ejs-mate engine', t => {
   })
 })
 
-test('reply.view for ejs-mate engine without data-parameter', t => {
+test('reply.view for ejs-mate engine without data-parameter but with defaultContext', t => {
   t.plan(6)
   const fastify = Fastify()
   const ejsMate = require('ejs-mate')
@@ -76,6 +77,39 @@ test('reply.view for ejs-mate engine without data-parameter', t => {
       t.strictEqual(response.headers['content-length'], '' + body.length)
       t.strictEqual(response.headers['content-type'], 'text/html; charset=utf-8')
       t.strictEqual('<html><head></head><body><h1>header</h1><div>text</div><div>footer</div></body></html>', body.toString())
+      fastify.close()
+    })
+  })
+})
+
+test('reply.view for ejs-mate engine without data and without defaultContext', t => {
+  t.plan(6)
+  const fastify = Fastify()
+  const ejsMate = require('ejs-mate')
+  const indexContent = fs.readFileSync('./templates/index-bare.html', 'utf-8')
+
+  fastify.register(require('../index'), {
+    engine: {
+      'ejs-mate': ejsMate
+    }
+  })
+
+  fastify.get('/', (req, reply) => {
+    reply.view('./templates/index-bare.html')
+  })
+
+  fastify.listen(0, err => {
+    t.error(err)
+
+    sget({
+      method: 'GET',
+      url: 'http://localhost:' + fastify.server.address().port
+    }, (err, response, body) => {
+      t.error(err)
+      t.strictEqual(response.statusCode, 200)
+      t.strictEqual(response.headers['content-length'], '' + body.length)
+      t.strictEqual(response.headers['content-type'], 'text/html; charset=utf-8')
+      t.strictEqual(indexContent, body.toString())
       fastify.close()
     })
   })

--- a/test/test-ejs.js
+++ b/test/test-ejs.js
@@ -50,6 +50,41 @@ test('reply.view with ejs engine and custom templates folder', t => {
   })
 })
 
+test('reply.view for ejs without data-parameter', t => {
+  t.plan(6)
+  const fastify = Fastify()
+  const ejs = require('ejs')
+  const data = { text: 'text' }
+
+  fastify.register(require('../index'), {
+    engine: {
+      ejs: ejs
+    },
+    defaultContext: data,
+    templates: 'templates'
+  })
+
+  fastify.get('/', (req, reply) => {
+    reply.view('index.ejs')
+  })
+
+  fastify.listen(0, err => {
+    t.error(err)
+
+    sget({
+      method: 'GET',
+      url: 'http://localhost:' + fastify.server.address().port
+    }, (err, response, body) => {
+      t.error(err)
+      t.strictEqual(response.statusCode, 200)
+      t.strictEqual(response.headers['content-length'], '' + body.length)
+      t.strictEqual(response.headers['content-type'], 'text/html; charset=utf-8')
+      t.strictEqual(ejs.render(fs.readFileSync('./templates/index.ejs', 'utf8'), data), body.toString())
+      fastify.close()
+    })
+  })
+})
+
 test('reply.view with ejs engine and full path templates folder', t => {
   t.plan(6)
   const fastify = Fastify()

--- a/test/test-ejs.js
+++ b/test/test-ejs.js
@@ -50,7 +50,7 @@ test('reply.view with ejs engine and custom templates folder', t => {
   })
 })
 
-test('reply.view for ejs without data-parameter', t => {
+test('reply.view for ejs without data-parameter but defaultContext', t => {
   t.plan(6)
   const fastify = Fastify()
   const ejs = require('ejs')
@@ -80,6 +80,39 @@ test('reply.view for ejs without data-parameter', t => {
       t.strictEqual(response.headers['content-length'], '' + body.length)
       t.strictEqual(response.headers['content-type'], 'text/html; charset=utf-8')
       t.strictEqual(ejs.render(fs.readFileSync('./templates/index.ejs', 'utf8'), data), body.toString())
+      fastify.close()
+    })
+  })
+})
+
+test('reply.view for ejs without data-parameter and without defaultContext', t => {
+  t.plan(6)
+  const fastify = Fastify()
+  const ejs = require('ejs')
+
+  fastify.register(require('../index'), {
+    engine: {
+      ejs: ejs
+    },
+    templates: 'templates'
+  })
+
+  fastify.get('/', (req, reply) => {
+    reply.view('index-bare.html')
+  })
+
+  fastify.listen(0, err => {
+    t.error(err)
+
+    sget({
+      method: 'GET',
+      url: 'http://localhost:' + fastify.server.address().port
+    }, (err, response, body) => {
+      t.error(err)
+      t.strictEqual(response.statusCode, 200)
+      t.strictEqual(response.headers['content-length'], '' + body.length)
+      t.strictEqual(response.headers['content-type'], 'text/html; charset=utf-8')
+      t.strictEqual(ejs.render(fs.readFileSync('./templates/index-bare.html', 'utf8')), body.toString())
       fastify.close()
     })
   })

--- a/test/test-handlebars.js
+++ b/test/test-handlebars.js
@@ -37,7 +37,7 @@ test('fastify.view with handlebars engine', t => {
   })
 })
 
-test('fastify.view for handlebars without data-parameter', t => {
+test('fastify.view for handlebars without data-parameter but defaultContext', t => {
   t.plan(2)
   const fastify = Fastify()
   const handlebars = require('handlebars')
@@ -55,6 +55,27 @@ test('fastify.view for handlebars without data-parameter', t => {
 
     fastify.view('./templates/index.html').then(compiled => {
       t.strictEqual(handlebars.compile(fs.readFileSync('./templates/index.html', 'utf8'))(data), compiled)
+      fastify.close()
+    })
+  })
+})
+
+test('fastify.view for handlebars without data-parameter and without defaultContext', t => {
+  t.plan(2)
+  const fastify = Fastify()
+  const handlebars = require('handlebars')
+
+  fastify.register(require('../index'), {
+    engine: {
+      handlebars: handlebars
+    }
+  })
+
+  fastify.ready(err => {
+    t.error(err)
+
+    fastify.view('./templates/index.html').then(compiled => {
+      t.strictEqual(handlebars.compile(fs.readFileSync('./templates/index.html', 'utf8'))(), compiled)
       fastify.close()
     })
   })

--- a/test/test-handlebars.js
+++ b/test/test-handlebars.js
@@ -37,6 +37,29 @@ test('fastify.view with handlebars engine', t => {
   })
 })
 
+test('fastify.view for handlebars without data-parameter', t => {
+  t.plan(2)
+  const fastify = Fastify()
+  const handlebars = require('handlebars')
+  const data = { text: 'text' }
+
+  fastify.register(require('../index'), {
+    engine: {
+      handlebars: handlebars
+    },
+    defaultContext: data
+  })
+
+  fastify.ready(err => {
+    t.error(err)
+
+    fastify.view('./templates/index.html').then(compiled => {
+      t.strictEqual(handlebars.compile(fs.readFileSync('./templates/index.html', 'utf8'))(data), compiled)
+      fastify.close()
+    })
+  })
+})
+
 test('fastify.view with handlebars engine and defaultContext', t => {
   t.plan(2)
   const fastify = Fastify()

--- a/test/test-marko.js
+++ b/test/test-marko.js
@@ -47,7 +47,7 @@ test('reply.view with marko engine', t => {
   })
 })
 
-test('reply.view for marko without data-parameter', t => {
+test('reply.view for marko without data-parameter but defaultContext', t => {
   t.plan(6)
   const fastify = Fastify()
   const marko = require('marko')
@@ -76,6 +76,38 @@ test('reply.view for marko without data-parameter', t => {
       t.strictEqual(response.headers['content-length'], '' + body.length)
       t.strictEqual(response.headers['content-type'], 'text/html; charset=utf-8')
       t.strictEqual(marko.load('./templates/index.marko').renderToString(data), body.toString())
+      fastify.close()
+    })
+  })
+})
+
+test('reply.view for marko without data-parameter but without defaultContext', t => {
+  t.plan(6)
+  const fastify = Fastify()
+  const marko = require('marko')
+
+  fastify.register(require('../index'), {
+    engine: {
+      marko: marko
+    }
+  })
+
+  fastify.get('/', (req, reply) => {
+    reply.view('./templates/index.marko')
+  })
+
+  fastify.listen(0, err => {
+    t.error(err)
+
+    sget({
+      method: 'GET',
+      url: 'http://localhost:' + fastify.server.address().port
+    }, (err, response, body) => {
+      t.error(err)
+      t.strictEqual(response.statusCode, 200)
+      t.strictEqual(response.headers['content-length'], '' + body.length)
+      t.strictEqual(response.headers['content-type'], 'text/html; charset=utf-8')
+      t.strictEqual(marko.load('./templates/index.marko').renderToString(), body.toString())
       fastify.close()
     })
   })

--- a/test/test-marko.js
+++ b/test/test-marko.js
@@ -47,6 +47,40 @@ test('reply.view with marko engine', t => {
   })
 })
 
+test('reply.view for marko without data-parameter', t => {
+  t.plan(6)
+  const fastify = Fastify()
+  const marko = require('marko')
+  const data = { text: 'text' }
+
+  fastify.register(require('../index'), {
+    engine: {
+      marko: marko
+    },
+    defaultContext: data
+  })
+
+  fastify.get('/', (req, reply) => {
+    reply.view('./templates/index.marko')
+  })
+
+  fastify.listen(0, err => {
+    t.error(err)
+
+    sget({
+      method: 'GET',
+      url: 'http://localhost:' + fastify.server.address().port
+    }, (err, response, body) => {
+      t.error(err)
+      t.strictEqual(response.statusCode, 200)
+      t.strictEqual(response.headers['content-length'], '' + body.length)
+      t.strictEqual(response.headers['content-type'], 'text/html; charset=utf-8')
+      t.strictEqual(marko.load('./templates/index.marko').renderToString(data), body.toString())
+      fastify.close()
+    })
+  })
+})
+
 test('reply.view with marko engine and defaultContext', t => {
   t.plan(6)
   const fastify = Fastify()

--- a/test/test-mustache.js
+++ b/test/test-mustache.js
@@ -48,6 +48,40 @@ test('reply.view with mustache engine', t => {
   })
 })
 
+test('reply.view for mustache without data-parameter', t => {
+  t.plan(6)
+  const fastify = Fastify()
+  const mustache = require('mustache')
+  const data = { text: 'text' }
+
+  fastify.register(require('../index'), {
+    engine: {
+      mustache: mustache
+    },
+    defaultContext: data
+  })
+
+  fastify.get('/', (req, reply) => {
+    reply.view('./templates/index.html')
+  })
+
+  fastify.listen(0, err => {
+    t.error(err)
+
+    sget({
+      method: 'GET',
+      url: 'http://localhost:' + fastify.server.address().port
+    }, (err, response, body) => {
+      t.error(err)
+      t.strictEqual(response.statusCode, 200)
+      t.strictEqual(response.headers['content-length'], '' + body.length)
+      t.strictEqual(response.headers['content-type'], 'text/html; charset=utf-8')
+      t.strictEqual(mustache.render(fs.readFileSync('./templates/index.html', 'utf8'), data), body.toString())
+      fastify.close()
+    })
+  })
+})
+
 test('reply.view with mustache engine and defaultContext', t => {
   t.plan(6)
   const fastify = Fastify()

--- a/test/test-mustache.js
+++ b/test/test-mustache.js
@@ -48,7 +48,7 @@ test('reply.view with mustache engine', t => {
   })
 })
 
-test('reply.view for mustache without data-parameter', t => {
+test('reply.view for mustache without data-parameter but defaultContext', t => {
   t.plan(6)
   const fastify = Fastify()
   const mustache = require('mustache')
@@ -77,6 +77,39 @@ test('reply.view for mustache without data-parameter', t => {
       t.strictEqual(response.headers['content-length'], '' + body.length)
       t.strictEqual(response.headers['content-type'], 'text/html; charset=utf-8')
       t.strictEqual(mustache.render(fs.readFileSync('./templates/index.html', 'utf8'), data), body.toString())
+      fastify.close()
+    })
+  })
+})
+
+test('reply.view for mustache without data-parameter and without defaultContext', t => {
+  t.plan(6)
+  const fastify = Fastify()
+  const mustache = require('mustache')
+
+  fastify.register(require('../index'), {
+    engine: {
+      mustache: mustache
+    }
+  })
+
+  fastify.get('/', (req, reply) => {
+    // Reusing the ejs-template is possible because it contains no tags
+    reply.view('./templates/index-bare.html')
+  })
+
+  fastify.listen(0, err => {
+    t.error(err)
+
+    sget({
+      method: 'GET',
+      url: 'http://localhost:' + fastify.server.address().port
+    }, (err, response, body) => {
+      t.error(err)
+      t.strictEqual(response.statusCode, 200)
+      t.strictEqual(response.headers['content-length'], '' + body.length)
+      t.strictEqual(response.headers['content-type'], 'text/html; charset=utf-8')
+      t.strictEqual(mustache.render(fs.readFileSync('./templates/index-bare.html', 'utf8')), body.toString())
       fastify.close()
     })
   })

--- a/test/test-nunjucks.js
+++ b/test/test-nunjucks.js
@@ -50,6 +50,42 @@ test('reply.view with nunjucks engine and custom templates folder', t => {
   })
 })
 
+test('reply.view for nunjucks engine without data-parameter', t => {
+  t.plan(6)
+  const fastify = Fastify()
+  const nunjucks = require('nunjucks')
+  const data = { text: 'text' }
+
+  fastify.register(require('../index'), {
+    engine: {
+      nunjucks: nunjucks
+    },
+    templates: 'templates',
+    defaultContext: data
+  })
+
+  fastify.get('/', (req, reply) => {
+    reply.view('./index.njk')
+  })
+
+  fastify.listen(0, err => {
+    t.error(err)
+
+    sget({
+      method: 'GET',
+      url: 'http://localhost:' + fastify.server.address().port
+    }, (err, response, body) => {
+      t.error(err)
+      t.strictEqual(response.statusCode, 200)
+      t.strictEqual(response.headers['content-length'], '' + body.length)
+      t.strictEqual(response.headers['content-type'], 'text/html; charset=utf-8')
+      // Global Nunjucks templates dir changed here.
+      t.strictEqual(nunjucks.render('./index.njk', data), body.toString())
+      fastify.close()
+    })
+  })
+})
+
 test('reply.view with nunjucks engine and full path templates folder', t => {
   t.plan(6)
   const fastify = Fastify()

--- a/test/test-nunjucks.js
+++ b/test/test-nunjucks.js
@@ -50,7 +50,7 @@ test('reply.view with nunjucks engine and custom templates folder', t => {
   })
 })
 
-test('reply.view for nunjucks engine without data-parameter', t => {
+test('reply.view for nunjucks engine without data-parameter but defaultContext', t => {
   t.plan(6)
   const fastify = Fastify()
   const nunjucks = require('nunjucks')
@@ -81,6 +81,40 @@ test('reply.view for nunjucks engine without data-parameter', t => {
       t.strictEqual(response.headers['content-type'], 'text/html; charset=utf-8')
       // Global Nunjucks templates dir changed here.
       t.strictEqual(nunjucks.render('./index.njk', data), body.toString())
+      fastify.close()
+    })
+  })
+})
+
+test('reply.view for nunjucks engine without data-parameter and without defaultContext', t => {
+  t.plan(6)
+  const fastify = Fastify()
+  const nunjucks = require('nunjucks')
+
+  fastify.register(require('../index'), {
+    engine: {
+      nunjucks: nunjucks
+    },
+    templates: 'templates'
+  })
+
+  fastify.get('/', (req, reply) => {
+    reply.view('./index.njk')
+  })
+
+  fastify.listen(0, err => {
+    t.error(err)
+
+    sget({
+      method: 'GET',
+      url: 'http://localhost:' + fastify.server.address().port
+    }, (err, response, body) => {
+      t.error(err)
+      t.strictEqual(response.statusCode, 200)
+      t.strictEqual(response.headers['content-length'], '' + body.length)
+      t.strictEqual(response.headers['content-type'], 'text/html; charset=utf-8')
+      // Global Nunjucks templates dir changed here.
+      t.strictEqual(nunjucks.render('./index.njk'), body.toString())
       fastify.close()
     })
   })

--- a/test/test-pug.js
+++ b/test/test-pug.js
@@ -48,7 +48,7 @@ test('reply.view with pug engine', t => {
   })
 })
 
-test('reply.view for pug without data-parameter', t => {
+test('reply.view for pug without data-parameter but defaultContext', t => {
   t.plan(6)
   const fastify = Fastify()
   const pug = require('pug')
@@ -77,6 +77,38 @@ test('reply.view for pug without data-parameter', t => {
       t.strictEqual(response.headers['content-length'], '' + body.length)
       t.strictEqual(response.headers['content-type'], 'text/html; charset=utf-8')
       t.strictEqual(pug.render(fs.readFileSync('./templates/index.pug', 'utf8'), data), body.toString())
+      fastify.close()
+    })
+  })
+})
+
+test('reply.view for pug without data-parameter and without defaultContext', t => {
+  t.plan(6)
+  const fastify = Fastify()
+  const pug = require('pug')
+
+  fastify.register(require('../index'), {
+    engine: {
+      pug: pug
+    }
+  })
+
+  fastify.get('/', (req, reply) => {
+    reply.view('./templates/index.pug')
+  })
+
+  fastify.listen(0, err => {
+    t.error(err)
+
+    sget({
+      method: 'GET',
+      url: 'http://localhost:' + fastify.server.address().port
+    }, (err, response, body) => {
+      t.error(err)
+      t.strictEqual(response.statusCode, 200)
+      t.strictEqual(response.headers['content-length'], '' + body.length)
+      t.strictEqual(response.headers['content-type'], 'text/html; charset=utf-8')
+      t.strictEqual(pug.render(fs.readFileSync('./templates/index.pug', 'utf8')), body.toString())
       fastify.close()
     })
   })

--- a/test/test-pug.js
+++ b/test/test-pug.js
@@ -48,6 +48,40 @@ test('reply.view with pug engine', t => {
   })
 })
 
+test('reply.view for pug without data-parameter', t => {
+  t.plan(6)
+  const fastify = Fastify()
+  const pug = require('pug')
+  const data = { text: 'text' }
+
+  fastify.register(require('../index'), {
+    engine: {
+      pug: pug
+    },
+    defaultContext: data
+  })
+
+  fastify.get('/', (req, reply) => {
+    reply.view('./templates/index.pug')
+  })
+
+  fastify.listen(0, err => {
+    t.error(err)
+
+    sget({
+      method: 'GET',
+      url: 'http://localhost:' + fastify.server.address().port
+    }, (err, response, body) => {
+      t.error(err)
+      t.strictEqual(response.statusCode, 200)
+      t.strictEqual(response.headers['content-length'], '' + body.length)
+      t.strictEqual(response.headers['content-type'], 'text/html; charset=utf-8')
+      t.strictEqual(pug.render(fs.readFileSync('./templates/index.pug', 'utf8'), data), body.toString())
+      fastify.close()
+    })
+  })
+})
+
 test('reply.view with pug engine and defaultContext', t => {
   t.plan(6)
   const fastify = Fastify()


### PR DESCRIPTION
Currently the data-parameter of

    .view(page, data)

is mandatory even tough the data object gets reassigned to an empty object in combination with the `defaultContext`-object. Omitting the data-parameter raises the `Missing Data`-error.

I removed the data-parameter from the `Missing Data`-validation to remove the necessity to provide an empty data-object.




#### Checklist

- [x] run `npm run test` ~~and `npm run benchmark`~~
- [x] tests and/or benchmarks are included
- [x] ~~documentation is changed or added~~
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)

- The change is not benchmarked, since i removed one Short Circuit Condition.
- The change is not being documented, since the data-parameter seems not being explicitly documented anywhere.
