### PR TITLE
Fix ejs templates relative paths (in doc and examples) for latest EJS release

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,8 +120,9 @@ const resolve = require('path').resolve
 ```
 and in ejs template files (for example templates/index.ejs) use something like:
 ```html
-<% include templates/header.ejs %>
+<% include header.ejs %>
 ```
+with a path relative to the current page, or an absolute path.
 
 To use partials in mustache you will need to pass the names and paths in the options parameter:
 ```js

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,18 +1,24 @@
+import { Plugin } from 'fastify';
+import { IncomingMessage, Server, ServerResponse } from 'http';
+
 declare module "fastify" {
   interface FastifyReply<HttpResponse> {
     view(page: string, data?: object): FastifyReply<HttpResponse>;
   }
 }
 
-declare function pointOfView(): void;
-
-declare namespace pointOfView {
-  interface PointOfViewOptions {
-    engine: object;
-    templates?: string;
-    includeViewExtension?: boolean;
-    options?: object;
-  }
+interface PointOfViewOptions {
+  engine: object;
+  templates?: string;
+  includeViewExtension?: boolean;
+  options?: object;
 }
+
+declare const pointOfView: Plugin<
+  Server,
+  IncomingMessage,
+  ServerResponse,
+  PointOfViewOptions
+>;
 
 export = pointOfView;

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   "devDependencies": {
     "art-template": "^4.13.2",
     "cross-env": "^5.2.0",
-    "ejs": "^2.6.1",
+    "ejs": "^2.7.1",
     "ejs-mate": "^2.3.0",
     "express": "^4.16.4",
     "fastify": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "example": "node example.js",
     "example-with-options": "node example-ejs-with-some-options.js",
+    "example-typescript": "npx ts-node types.test.ts",
     "test-with-snapshot": "standard && cross-env TAP_SNAPSHOT=1 tap test/test-ejs-with-snapshot.js",
     "test": "standard && tap -J test/* && tsc"
   },

--- a/templates/index-with-includes-and-attribute-missing.ejs
+++ b/templates/index-with-includes-and-attribute-missing.ejs
@@ -2,9 +2,9 @@
 <html lang="en">
   <head></head>
   <body>
-    <% include templates/fragment-header.ejs %>
+    <% include fragment-header.ejs %>
     <p><%= text %></p>
     <p>A not existing page attribute: <%= not_existing_text %></p>
-    <% include templates/fragment-footer.html %>
+    <% include fragment-footer.html %>
   </body>
 </html>

--- a/templates/index-with-includes-one-missing.ejs
+++ b/templates/index-with-includes-one-missing.ejs
@@ -2,9 +2,9 @@
 <html lang="en">
   <head></head>
   <body>
-    <% include templates/fragment-header.ejs %>
-    <% include templates/fragment-content-not-existing.ejs %>
+    <% include fragment-header.ejs %>
+    <% include fragment-content-not-existing.ejs %>
     <p><%= text %></p>
-    <% include templates/fragment-footer.html %>
+    <% include fragment-footer.html %>
   </body>
 </html>

--- a/templates/index-with-includes.ejs
+++ b/templates/index-with-includes.ejs
@@ -2,8 +2,8 @@
 <html lang="en">
   <head></head>
   <body>
-    <% include templates/fragment-header.ejs %>
+    <% include fragment-header.ejs %>
     <p><%= text %></p>
-    <% include templates/fragment-footer.html %>
+    <% include fragment-footer.html %>
   </body>
 </html>

--- a/types.test.ts
+++ b/types.test.ts
@@ -3,7 +3,7 @@ import pointOfView = require("./");
 
 const app = fastify();
 
-app.register<pointOfView.PointOfViewOptions>(pointOfView, {
+app.register(pointOfView, {
   engine: {
     ejs: require("ejs"),
   },
@@ -11,9 +11,14 @@ app.register<pointOfView.PointOfViewOptions>(pointOfView, {
 });
 
 app.get("/", (request, reply) => {
-  reply.view("/index.ejs");
+  reply.view("/index-with-no-data.ejs");
 });
 
 app.get("/data", (request, reply) => {
-  reply.view("/data.ejs", { data: "data" });
+  reply.view("/index.ejs", { text: "Sample data" });
 });
+
+app.listen(3000, (err, address) => {
+  if (err) throw err
+  console.log(`server listening on ${address} ...`)
+})


### PR DESCRIPTION
Hi all,
this PR  set in an explicit way latest EJS release and update related info in the README and in sample templates, so templates/fragments works even with latest EJS release.
Note that the problem is not visible in tests, but only executing npm custom command 'example-with-options' and browse into linked pages, and I think it's caused by some changes in latest ejs release (good relative path between pages and fragments).

Last, tests currently are failing due to a TypeScript error (it was the same even before my changes), if someone has some hint I can add even that fix in this PR.

For info tell me.
Bye

#### Checklist

- [X] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [X] documentation is changed or added
- [X] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
