### PR TITLE
Add async example in usage section

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,13 @@ fastify.get('/', (req, reply) => {
   reply.view('/templates/index.ejs', { text: 'text' })
 })
 
+// With async handler you must return the reply object
+fastify.get('/', async (req, reply) => {
+  const t = await something()
+  reply.view('/templates/index.ejs', { text: 'text' })
+  return reply
+})
+
 fastify.listen(3000, err => {
   if (err) throw err
   console.log(`server listening on ${fastify.server.address().port}`)


### PR DESCRIPTION
A quick update on the usage readme to include an async example and the requirement to return the reply object.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Tip: `npm run bench` to compare branches interactively.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
