### PR TITLE
Document dropping support for ejs-mate.

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,6 @@ Templates rendering plugin support for Fastify.
 
 Currently supports the following templates engines:
 - [`ejs`](https://ejs.co/)
-- [`ejs-mate`](https://github.com/JacksonTian/ejs-mate)
 - [`nunjucks`](https://mozilla.github.io/nunjucks/)
 - [`pug`](https://pugjs.org/api/getting-started.html)
 - [`handlebars`](http://handlebarsjs.com/)
@@ -21,6 +20,8 @@ Currently supports the following templates engines:
 In `production` mode, `point-of-view` will heavily cache the templates file and functions, while in `development` will reload every time the template file and function.
 
 *Note that at least Fastify `v2.0.0` is needed.*
+
+*Note: [`ejs-mate`](https://github.com/JacksonTian/ejs-mate) support [has been dropped](https://github.com/fastify/point-of-view/pull/157).*
 
 #### Benchmarks
 The benchmark were run with the files in the `benchmark` folder with the `ejs` engine.

--- a/index.d.ts
+++ b/index.d.ts
@@ -13,7 +13,6 @@ export interface PointOfViewOptions {
     pug?: any;
     handlebars?: any;
     marko?: any;
-    'ejs-mate'?: any;
     mustache?: any;
     'art-template'?: any;
   };


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Tip: `npm run bench` to compare branches interactively.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md
-->

Support for `ejs-mate` has been dropped in https://github.com/fastify/point-of-view/pull/157, but it was still appearing on the front page. This PR removes it from the `README.md` file, and also the typing.

Note that there is only a trivial code change. I only have a puny laptop so I will not even attempt `npm run benchmark` :sweat_smile:

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [-] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
