### PR TITLE
add twig engine to definitions

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -15,6 +15,7 @@ export interface PointOfViewOptions {
     marko?: any;
     mustache?: any;
     'art-template'?: any;
+    twig?: any
   };
   templates?: string;
   includeViewExtension?: boolean;

--- a/test/index.test-d.ts
+++ b/test/index.test-d.ts
@@ -1,5 +1,6 @@
 import fastify from "fastify";
-import pointOfView from "..";
+import pointOfView, {PointOfViewOptions} from "..";
+import {expectAssignable, expectType} from "tsd";
 
 const app = fastify();
 
@@ -31,3 +32,5 @@ app.listen(3000, (err, address) => {
   if (err) throw err
   console.log(`server listening on ${address} ...`)
 })
+
+expectAssignable<PointOfViewOptions>({engine: {twig: require('twig') } })

--- a/test/index.test-d.ts
+++ b/test/index.test-d.ts
@@ -1,6 +1,6 @@
 import fastify from "fastify";
 import pointOfView, {PointOfViewOptions} from "..";
-import {expectAssignable, expectType} from "tsd";
+import {expectAssignable} from "tsd";
 
 const app = fastify();
 


### PR DESCRIPTION
Added twig to the definitions file. 
Fixes unsupported type when using point-of-view with typescript.

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [-] tests and/or benchmarks are included
- [-] documentation is changed or added
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
