### PR TITLE
Add ability to override defaultContext properties with ones from reply locals

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,6 +228,18 @@ The optional boolean property `production` will override environment variable `N
   }
 ```
 
+If you want to provide data which will be dependand on e.g. request and available in all views you have to add propert `locals` to `reply` object, like in the example below:
+```js
+fastify.addHook('preHandler', function (request, reply, done) {
+  reply.locals = {
+    text: getTextFromRequest(request) // it will be available in all views
+  }
+
+  done()
+})
+```
+Properites from `reply.locals` will override those from `defaultContext`, but not from `data` parameter provided to `reply.view(template, data)` function.
+
 <a name="note"></a>
 ## Note
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -3,6 +3,7 @@ import { FastifyPlugin, FastifyReply, RawServerBase } from 'fastify';
 declare module "fastify" {
   interface FastifyReplyInterface {
     view(page: string, data?: object): FastifyReply;
+    locals?: object;
   }
 }
 

--- a/index.js
+++ b/index.js
@@ -196,7 +196,7 @@ function fastifyView (fastify, opts, next) {
       return
     }
 
-    data = Object.assign({}, defaultCtx, data)
+    data = Object.assign({}, defaultCtx, this.locals, data)
     // append view extension
     page = getPage(page, type)
 
@@ -218,7 +218,7 @@ function fastifyView (fastify, opts, next) {
       this.send(new Error('Missing page'))
       return
     }
-    data = Object.assign({}, defaultCtx, data)
+    data = Object.assign({}, defaultCtx, this.locals, data)
     // append view extension
     page = getPage(page, type)
     getTemplate(page, (err, template) => {
@@ -243,7 +243,7 @@ function fastifyView (fastify, opts, next) {
       this.send(new Error('Missing page'))
       return
     }
-    data = Object.assign({}, defaultCtx, data)
+    data = Object.assign({}, defaultCtx, this.locals, data)
     // Append view extension.
     page = getPage(page, 'art')
 
@@ -281,7 +281,7 @@ function fastifyView (fastify, opts, next) {
     if (typeof options.onConfigure === 'function') {
       options.onConfigure(env)
     }
-    data = Object.assign({}, defaultCtx, data)
+    data = Object.assign({}, defaultCtx, this.locals, data)
     // Append view extension.
     page = getPage(page, 'njk')
     env.render(join(templatesDir, page), data, (err, html) => {
@@ -299,7 +299,7 @@ function fastifyView (fastify, opts, next) {
       return
     }
 
-    data = Object.assign({}, defaultCtx, data)
+    data = Object.assign({}, defaultCtx, this.locals, data)
     // append view extension
     page = getPage(page, type)
 
@@ -333,7 +333,7 @@ function fastifyView (fastify, opts, next) {
     }
 
     const options = Object.assign({}, opts.options)
-    data = Object.assign({}, defaultCtx, data)
+    data = Object.assign({}, defaultCtx, this.locals, data)
     // append view extension
     page = getPage(page, 'hbs')
     getTemplate(page, (err, template) => {
@@ -385,7 +385,7 @@ function fastifyView (fastify, opts, next) {
     }
 
     const options = Object.assign({}, opts)
-    data = Object.assign({}, defaultCtx, data)
+    data = Object.assign({}, defaultCtx, this.locals, data)
     // append view extension
     page = getPage(page, 'mustache')
     getTemplate(page, (err, templateString) => {
@@ -414,8 +414,7 @@ function fastifyView (fastify, opts, next) {
       return
     }
 
-    data = Object.assign({}, defaultCtx, options, data)
-
+    data = Object.assign({}, defaultCtx, options, this.locals, data)
     // Append view extension.
     page = getPage(page, 'twig')
     engine.renderFile(join(templatesDir, page), data, (err, html) => {

--- a/test/test-art-template.js
+++ b/test/test-art-template.js
@@ -155,6 +155,176 @@ test('reply.view with art-template engine and defaultContext', t => {
   })
 })
 
+test('reply.view for art-template engine without data-parameter and defaultContext but with reply.locals', t => {
+  t.plan(6)
+  const fastify = Fastify()
+  const art = require('art-template')
+  const localsData = { text: 'text from locals' }
+
+  fastify.register(require('../index'), {
+    engine: {
+      'art-template': art
+    }
+  })
+
+  fastify.addHook('preHandler', function (request, reply, done) {
+    reply.locals = localsData
+    done()
+  })
+
+  fastify.get('/', (req, reply) => {
+    reply.view('./templates/index.art')
+  })
+
+  fastify.listen(0, err => {
+    t.error(err)
+
+    sget({
+      method: 'GET',
+      url: 'http://localhost:' + fastify.server.address().port
+    }, (err, response, body) => {
+      t.error(err)
+      t.strictEqual(response.statusCode, 200)
+      t.strictEqual(response.headers['content-length'], '' + body.length)
+      t.strictEqual(response.headers['content-type'], 'text/html; charset=utf-8')
+
+      const templatePath = path.join(__dirname, '..', 'templates', 'index.art')
+
+      t.strictEqual(art(templatePath, localsData), body.toString())
+      fastify.close()
+    })
+  })
+})
+
+test('reply.view for art-template engine without defaultContext but with reply.locals and data-parameter', t => {
+  t.plan(6)
+  const fastify = Fastify()
+  const art = require('art-template')
+  const localsData = { text: 'text from locals' }
+  const data = { text: 'text' }
+
+  fastify.register(require('../index'), {
+    engine: {
+      'art-template': art
+    }
+  })
+
+  fastify.addHook('preHandler', function (request, reply, done) {
+    reply.locals = localsData
+    done()
+  })
+
+  fastify.get('/', (req, reply) => {
+    reply.view('./templates/index.art', data)
+  })
+
+  fastify.listen(0, err => {
+    t.error(err)
+
+    sget({
+      method: 'GET',
+      url: 'http://localhost:' + fastify.server.address().port
+    }, (err, response, body) => {
+      t.error(err)
+      t.strictEqual(response.statusCode, 200)
+      t.strictEqual(response.headers['content-length'], '' + body.length)
+      t.strictEqual(response.headers['content-type'], 'text/html; charset=utf-8')
+
+      const templatePath = path.join(__dirname, '..', 'templates', 'index.art')
+
+      t.strictEqual(art(templatePath, data), body.toString())
+      fastify.close()
+    })
+  })
+})
+
+test('reply.view for art-template engine without data-parameter but with reply.locals and defaultContext', t => {
+  t.plan(6)
+  const fastify = Fastify()
+  const art = require('art-template')
+  const localsData = { text: 'text from locals' }
+  const contextData = { text: 'text from context' }
+
+  fastify.register(require('../index'), {
+    engine: {
+      'art-template': art
+    },
+    defaultContext: contextData
+  })
+
+  fastify.addHook('preHandler', function (request, reply, done) {
+    reply.locals = localsData
+    done()
+  })
+
+  fastify.get('/', (req, reply) => {
+    reply.view('./templates/index.art')
+  })
+
+  fastify.listen(0, err => {
+    t.error(err)
+
+    sget({
+      method: 'GET',
+      url: 'http://localhost:' + fastify.server.address().port
+    }, (err, response, body) => {
+      t.error(err)
+      t.strictEqual(response.statusCode, 200)
+      t.strictEqual(response.headers['content-length'], '' + body.length)
+      t.strictEqual(response.headers['content-type'], 'text/html; charset=utf-8')
+
+      const templatePath = path.join(__dirname, '..', 'templates', 'index.art')
+
+      t.strictEqual(art(templatePath, localsData), body.toString())
+      fastify.close()
+    })
+  })
+})
+
+test('reply.view for art-template engine with data-parameter and reply.locals and defaultContext', t => {
+  t.plan(6)
+  const fastify = Fastify()
+  const art = require('art-template')
+  const localsData = { text: 'text from locals' }
+  const contextData = { text: 'text from context' }
+  const data = { text: 'text' }
+
+  fastify.register(require('../index'), {
+    engine: {
+      'art-template': art
+    },
+    defaultContext: contextData
+  })
+
+  fastify.addHook('preHandler', function (request, reply, done) {
+    reply.locals = localsData
+    done()
+  })
+
+  fastify.get('/', (req, reply) => {
+    reply.view('./templates/index.art', data)
+  })
+
+  fastify.listen(0, err => {
+    t.error(err)
+
+    sget({
+      method: 'GET',
+      url: 'http://localhost:' + fastify.server.address().port
+    }, (err, response, body) => {
+      t.error(err)
+      t.strictEqual(response.statusCode, 200)
+      t.strictEqual(response.headers['content-length'], '' + body.length)
+      t.strictEqual(response.headers['content-type'], 'text/html; charset=utf-8')
+
+      const templatePath = path.join(__dirname, '..', 'templates', 'index.art')
+
+      t.strictEqual(art(templatePath, data), body.toString())
+      fastify.close()
+    })
+  })
+})
+
 test('reply.view with art-template engine and full path templates folder', t => {
   t.plan(6)
 

--- a/test/test-ejs.js
+++ b/test/test-ejs.js
@@ -154,6 +154,7 @@ test('reply.view for ejs without data-parameter but defaultContext', t => {
     })
   })
 })
+
 test('reply.view for ejs without data-parameter but defaultContext', t => {
   t.plan(6)
   const fastify = Fastify()
@@ -217,6 +218,164 @@ test('reply.view for ejs without data-parameter and without defaultContext', t =
       t.strictEqual(response.headers['content-length'], '' + body.length)
       t.strictEqual(response.headers['content-type'], 'text/html; charset=utf-8')
       t.strictEqual(ejs.render(fs.readFileSync('./templates/index-bare.html', 'utf8')), body.toString())
+      fastify.close()
+    })
+  })
+})
+
+test('reply.view for ejs engine without data-parameter and defaultContext but with reply.locals', t => {
+  t.plan(6)
+  const fastify = Fastify()
+  const ejs = require('ejs')
+  const localsData = { text: 'text from locals' }
+
+  fastify.register(require('../index'), {
+    engine: {
+      ejs: ejs
+    }
+  })
+
+  fastify.addHook('preHandler', function (request, reply, done) {
+    reply.locals = localsData
+    done()
+  })
+
+  fastify.get('/', (req, reply) => {
+    reply.view('./templates/index-bare.html')
+  })
+
+  fastify.listen(0, err => {
+    t.error(err)
+
+    sget({
+      method: 'GET',
+      url: 'http://localhost:' + fastify.server.address().port
+    }, (err, response, body) => {
+      t.error(err)
+      t.strictEqual(response.statusCode, 200)
+      t.strictEqual(response.headers['content-length'], '' + body.length)
+      t.strictEqual(response.headers['content-type'], 'text/html; charset=utf-8')
+      t.strictEqual(ejs.render(fs.readFileSync('./templates/index-bare.html', 'utf8'), localsData), body.toString())
+      fastify.close()
+    })
+  })
+})
+
+test('reply.view for ejs engine without defaultContext but with reply.locals and data-parameter', t => {
+  t.plan(6)
+  const fastify = Fastify()
+  const ejs = require('ejs')
+  const localsData = { text: 'text from locals' }
+  const data = { text: 'text' }
+
+  fastify.register(require('../index'), {
+    engine: {
+      ejs: ejs
+    }
+  })
+
+  fastify.addHook('preHandler', function (request, reply, done) {
+    reply.locals = localsData
+    done()
+  })
+
+  fastify.get('/', (req, reply) => {
+    reply.view('./templates/index-bare.html', data)
+  })
+
+  fastify.listen(0, err => {
+    t.error(err)
+
+    sget({
+      method: 'GET',
+      url: 'http://localhost:' + fastify.server.address().port
+    }, (err, response, body) => {
+      t.error(err)
+      t.strictEqual(response.statusCode, 200)
+      t.strictEqual(response.headers['content-length'], '' + body.length)
+      t.strictEqual(response.headers['content-type'], 'text/html; charset=utf-8')
+      t.strictEqual(ejs.render(fs.readFileSync('./templates/index-bare.html', 'utf8'), data), body.toString())
+      fastify.close()
+    })
+  })
+})
+
+test('reply.view for ejs engine without data-parameter but with reply.locals and defaultContext', t => {
+  t.plan(6)
+  const fastify = Fastify()
+  const ejs = require('ejs')
+  const localsData = { text: 'text from locals' }
+  const contextData = { text: 'text from context' }
+
+  fastify.register(require('../index'), {
+    engine: {
+      ejs: ejs
+    },
+    defaultContext: contextData
+  })
+
+  fastify.addHook('preHandler', function (request, reply, done) {
+    reply.locals = localsData
+    done()
+  })
+
+  fastify.get('/', (req, reply) => {
+    reply.view('./templates/index-bare.html')
+  })
+
+  fastify.listen(0, err => {
+    t.error(err)
+
+    sget({
+      method: 'GET',
+      url: 'http://localhost:' + fastify.server.address().port
+    }, (err, response, body) => {
+      t.error(err)
+      t.strictEqual(response.statusCode, 200)
+      t.strictEqual(response.headers['content-length'], '' + body.length)
+      t.strictEqual(response.headers['content-type'], 'text/html; charset=utf-8')
+      t.strictEqual(ejs.render(fs.readFileSync('./templates/index-bare.html', 'utf8'), localsData), body.toString())
+      fastify.close()
+    })
+  })
+})
+
+test('reply.view for ejs engine with data-parameter and reply.locals and defaultContext', t => {
+  t.plan(6)
+  const fastify = Fastify()
+  const ejs = require('ejs')
+  const localsData = { text: 'text from locals' }
+  const contextData = { text: 'text from context' }
+  const data = { text: 'text' }
+
+  fastify.register(require('../index'), {
+    engine: {
+      ejs: ejs
+    },
+    defaultContext: contextData
+  })
+
+  fastify.addHook('preHandler', function (request, reply, done) {
+    reply.locals = localsData
+    done()
+  })
+
+  fastify.get('/', (req, reply) => {
+    reply.view('./templates/index-bare.html', data)
+  })
+
+  fastify.listen(0, err => {
+    t.error(err)
+
+    sget({
+      method: 'GET',
+      url: 'http://localhost:' + fastify.server.address().port
+    }, (err, response, body) => {
+      t.error(err)
+      t.strictEqual(response.statusCode, 200)
+      t.strictEqual(response.headers['content-length'], '' + body.length)
+      t.strictEqual(response.headers['content-type'], 'text/html; charset=utf-8')
+      t.strictEqual(ejs.render(fs.readFileSync('./templates/index-bare.html', 'utf8'), data), body.toString())
       fastify.close()
     })
   })

--- a/test/test-handlebars.js
+++ b/test/test-handlebars.js
@@ -105,6 +105,164 @@ test('fastify.view with handlebars engine and defaultContext', t => {
   })
 })
 
+test('reply.view for handlebars engine without data-parameter and defaultContext but with reply.locals', t => {
+  t.plan(6)
+  const fastify = Fastify()
+  const handlebars = require('handlebars')
+  const localsData = { text: 'text from locals' }
+
+  fastify.register(require('../index'), {
+    engine: {
+      handlebars: handlebars
+    }
+  })
+
+  fastify.addHook('preHandler', function (request, reply, done) {
+    reply.locals = localsData
+    done()
+  })
+
+  fastify.get('/', (req, reply) => {
+    reply.view('./templates/index.html')
+  })
+
+  fastify.listen(0, err => {
+    t.error(err)
+
+    sget({
+      method: 'GET',
+      url: 'http://localhost:' + fastify.server.address().port
+    }, (err, response, body) => {
+      t.error(err)
+      t.strictEqual(response.statusCode, 200)
+      t.strictEqual(response.headers['content-length'], '' + body.length)
+      t.strictEqual(response.headers['content-type'], 'text/html; charset=utf-8')
+      t.strictEqual(handlebars.compile(fs.readFileSync('./templates/index.html', 'utf8'))(localsData), body.toString())
+      fastify.close()
+    })
+  })
+})
+
+test('reply.view for handlebars engine without defaultContext but with reply.locals and data-parameter', t => {
+  t.plan(6)
+  const fastify = Fastify()
+  const handlebars = require('handlebars')
+  const localsData = { text: 'text from locals' }
+  const data = { text: 'text' }
+
+  fastify.register(require('../index'), {
+    engine: {
+      handlebars: handlebars
+    }
+  })
+
+  fastify.addHook('preHandler', function (request, reply, done) {
+    reply.locals = localsData
+    done()
+  })
+
+  fastify.get('/', (req, reply) => {
+    reply.view('./templates/index.html', data)
+  })
+
+  fastify.listen(0, err => {
+    t.error(err)
+
+    sget({
+      method: 'GET',
+      url: 'http://localhost:' + fastify.server.address().port
+    }, (err, response, body) => {
+      t.error(err)
+      t.strictEqual(response.statusCode, 200)
+      t.strictEqual(response.headers['content-length'], '' + body.length)
+      t.strictEqual(response.headers['content-type'], 'text/html; charset=utf-8')
+      t.strictEqual(handlebars.compile(fs.readFileSync('./templates/index.html', 'utf8'))(data), body.toString())
+      fastify.close()
+    })
+  })
+})
+
+test('reply.view for handlebars engine without data-parameter but with reply.locals and defaultContext', t => {
+  t.plan(6)
+  const fastify = Fastify()
+  const handlebars = require('handlebars')
+  const localsData = { text: 'text from locals' }
+  const contextData = { text: 'text from context' }
+
+  fastify.register(require('../index'), {
+    engine: {
+      handlebars: handlebars
+    },
+    defaultContext: contextData
+  })
+
+  fastify.addHook('preHandler', function (request, reply, done) {
+    reply.locals = localsData
+    done()
+  })
+
+  fastify.get('/', (req, reply) => {
+    reply.view('./templates/index.html')
+  })
+
+  fastify.listen(0, err => {
+    t.error(err)
+
+    sget({
+      method: 'GET',
+      url: 'http://localhost:' + fastify.server.address().port
+    }, (err, response, body) => {
+      t.error(err)
+      t.strictEqual(response.statusCode, 200)
+      t.strictEqual(response.headers['content-length'], '' + body.length)
+      t.strictEqual(response.headers['content-type'], 'text/html; charset=utf-8')
+      t.strictEqual(handlebars.compile(fs.readFileSync('./templates/index.html', 'utf8'))(localsData), body.toString())
+      fastify.close()
+    })
+  })
+})
+
+test('reply.view for handlebars engine with data-parameter and reply.locals and defaultContext', t => {
+  t.plan(6)
+  const fastify = Fastify()
+  const handlebars = require('handlebars')
+  const localsData = { text: 'text from locals' }
+  const contextData = { text: 'text from context' }
+  const data = { text: 'text' }
+
+  fastify.register(require('../index'), {
+    engine: {
+      handlebars: handlebars
+    },
+    defaultContext: contextData
+  })
+
+  fastify.addHook('preHandler', function (request, reply, done) {
+    reply.locals = localsData
+    done()
+  })
+
+  fastify.get('/', (req, reply) => {
+    reply.view('./templates/index.html', data)
+  })
+
+  fastify.listen(0, err => {
+    t.error(err)
+
+    sget({
+      method: 'GET',
+      url: 'http://localhost:' + fastify.server.address().port
+    }, (err, response, body) => {
+      t.error(err)
+      t.strictEqual(response.statusCode, 200)
+      t.strictEqual(response.headers['content-length'], '' + body.length)
+      t.strictEqual(response.headers['content-type'], 'text/html; charset=utf-8')
+      t.strictEqual(handlebars.compile(fs.readFileSync('./templates/index.html', 'utf8'))(data), body.toString())
+      fastify.close()
+    })
+  })
+})
+
 test('fastify.view with handlebars engine and html-minifier', t => {
   t.plan(2)
   const fastify = Fastify()

--- a/test/test-marko.js
+++ b/test/test-marko.js
@@ -147,6 +147,164 @@ test('reply.view with marko engine and defaultContext', t => {
   })
 })
 
+test('reply.view for marko engine without data-parameter and defaultContext but with reply.locals', t => {
+  t.plan(6)
+  const fastify = Fastify()
+  const marko = require('marko')
+  const localsData = { text: 'text from locals' }
+
+  fastify.register(require('../index'), {
+    engine: {
+      marko: marko
+    }
+  })
+
+  fastify.addHook('preHandler', function (request, reply, done) {
+    reply.locals = localsData
+    done()
+  })
+
+  fastify.get('/', (req, reply) => {
+    reply.view('./templates/index.marko')
+  })
+
+  fastify.listen(0, err => {
+    t.error(err)
+
+    sget({
+      method: 'GET',
+      url: 'http://localhost:' + fastify.server.address().port
+    }, (err, response, body) => {
+      t.error(err)
+      t.strictEqual(response.statusCode, 200)
+      t.strictEqual(response.headers['content-length'], '' + body.length)
+      t.strictEqual(response.headers['content-type'], 'text/html; charset=utf-8')
+      t.strictEqual(marko.load('./templates/index.marko').renderToString(localsData), body.toString())
+      fastify.close()
+    })
+  })
+})
+
+test('reply.view for marko engine without defaultContext but with reply.locals and data-parameter', t => {
+  t.plan(6)
+  const fastify = Fastify()
+  const marko = require('marko')
+  const localsData = { text: 'text from locals' }
+  const data = { text: 'text' }
+
+  fastify.register(require('../index'), {
+    engine: {
+      marko: marko
+    }
+  })
+
+  fastify.addHook('preHandler', function (request, reply, done) {
+    reply.locals = localsData
+    done()
+  })
+
+  fastify.get('/', (req, reply) => {
+    reply.view('./templates/index.marko', data)
+  })
+
+  fastify.listen(0, err => {
+    t.error(err)
+
+    sget({
+      method: 'GET',
+      url: 'http://localhost:' + fastify.server.address().port
+    }, (err, response, body) => {
+      t.error(err)
+      t.strictEqual(response.statusCode, 200)
+      t.strictEqual(response.headers['content-length'], '' + body.length)
+      t.strictEqual(response.headers['content-type'], 'text/html; charset=utf-8')
+      t.strictEqual(marko.load('./templates/index.marko').renderToString(data), body.toString())
+      fastify.close()
+    })
+  })
+})
+
+test('reply.view for marko engine without data-parameter but with reply.locals and defaultContext', t => {
+  t.plan(6)
+  const fastify = Fastify()
+  const marko = require('marko')
+  const localsData = { text: 'text from locals' }
+  const contextData = { text: 'text from context' }
+
+  fastify.register(require('../index'), {
+    engine: {
+      marko: marko
+    },
+    defaultContext: contextData
+  })
+
+  fastify.addHook('preHandler', function (request, reply, done) {
+    reply.locals = localsData
+    done()
+  })
+
+  fastify.get('/', (req, reply) => {
+    reply.view('./templates/index.marko')
+  })
+
+  fastify.listen(0, err => {
+    t.error(err)
+
+    sget({
+      method: 'GET',
+      url: 'http://localhost:' + fastify.server.address().port
+    }, (err, response, body) => {
+      t.error(err)
+      t.strictEqual(response.statusCode, 200)
+      t.strictEqual(response.headers['content-length'], '' + body.length)
+      t.strictEqual(response.headers['content-type'], 'text/html; charset=utf-8')
+      t.strictEqual(marko.load('./templates/index.marko').renderToString(localsData), body.toString())
+      fastify.close()
+    })
+  })
+})
+
+test('reply.view for marko engine with data-parameter and reply.locals and defaultContext', t => {
+  t.plan(6)
+  const fastify = Fastify()
+  const marko = require('marko')
+  const localsData = { text: 'text from locals' }
+  const contextData = { text: 'text from context' }
+  const data = { text: 'text' }
+
+  fastify.register(require('../index'), {
+    engine: {
+      marko: marko
+    },
+    defaultContext: contextData
+  })
+
+  fastify.addHook('preHandler', function (request, reply, done) {
+    reply.locals = localsData
+    done()
+  })
+
+  fastify.get('/', (req, reply) => {
+    reply.view('./templates/index.marko', data)
+  })
+
+  fastify.listen(0, err => {
+    t.error(err)
+
+    sget({
+      method: 'GET',
+      url: 'http://localhost:' + fastify.server.address().port
+    }, (err, response, body) => {
+      t.error(err)
+      t.strictEqual(response.statusCode, 200)
+      t.strictEqual(response.headers['content-length'], '' + body.length)
+      t.strictEqual(response.headers['content-type'], 'text/html; charset=utf-8')
+      t.strictEqual(marko.load('./templates/index.marko').renderToString(data), body.toString())
+      fastify.close()
+    })
+  })
+})
+
 test('reply.view with marko engine and html-minifier', t => {
   t.plan(6)
   const fastify = Fastify()

--- a/test/test-mustache.js
+++ b/test/test-mustache.js
@@ -149,6 +149,164 @@ test('reply.view with mustache engine and defaultContext', t => {
   })
 })
 
+test('reply.view for mustache engine without data-parameter and defaultContext but with reply.locals', t => {
+  t.plan(6)
+  const fastify = Fastify()
+  const mustache = require('mustache')
+  const localsData = { text: 'text from locals' }
+
+  fastify.register(require('../index'), {
+    engine: {
+      mustache: mustache
+    }
+  })
+
+  fastify.addHook('preHandler', function (request, reply, done) {
+    reply.locals = localsData
+    done()
+  })
+
+  fastify.get('/', (req, reply) => {
+    reply.view('./templates/index.html')
+  })
+
+  fastify.listen(0, err => {
+    t.error(err)
+
+    sget({
+      method: 'GET',
+      url: 'http://localhost:' + fastify.server.address().port
+    }, (err, response, body) => {
+      t.error(err)
+      t.strictEqual(response.statusCode, 200)
+      t.strictEqual(response.headers['content-length'], '' + body.length)
+      t.strictEqual(response.headers['content-type'], 'text/html; charset=utf-8')
+      t.strictEqual(mustache.render(fs.readFileSync('./templates/index.html', 'utf8'), localsData), body.toString())
+      fastify.close()
+    })
+  })
+})
+
+test('reply.view for mustache engine without defaultContext but with reply.locals and data-parameter', t => {
+  t.plan(6)
+  const fastify = Fastify()
+  const mustache = require('mustache')
+  const localsData = { text: 'text from locals' }
+  const data = { text: 'text' }
+
+  fastify.register(require('../index'), {
+    engine: {
+      mustache: mustache
+    }
+  })
+
+  fastify.addHook('preHandler', function (request, reply, done) {
+    reply.locals = localsData
+    done()
+  })
+
+  fastify.get('/', (req, reply) => {
+    reply.view('./templates/index.html', data)
+  })
+
+  fastify.listen(0, err => {
+    t.error(err)
+
+    sget({
+      method: 'GET',
+      url: 'http://localhost:' + fastify.server.address().port
+    }, (err, response, body) => {
+      t.error(err)
+      t.strictEqual(response.statusCode, 200)
+      t.strictEqual(response.headers['content-length'], '' + body.length)
+      t.strictEqual(response.headers['content-type'], 'text/html; charset=utf-8')
+      t.strictEqual(mustache.render(fs.readFileSync('./templates/index.html', 'utf8'), data), body.toString())
+      fastify.close()
+    })
+  })
+})
+
+test('reply.view for mustache engine without data-parameter but with reply.locals and defaultContext', t => {
+  t.plan(6)
+  const fastify = Fastify()
+  const mustache = require('mustache')
+  const localsData = { text: 'text from locals' }
+  const contextData = { text: 'text from context' }
+
+  fastify.register(require('../index'), {
+    engine: {
+      mustache: mustache
+    },
+    defaultContext: contextData
+  })
+
+  fastify.addHook('preHandler', function (request, reply, done) {
+    reply.locals = localsData
+    done()
+  })
+
+  fastify.get('/', (req, reply) => {
+    reply.view('./templates/index.html')
+  })
+
+  fastify.listen(0, err => {
+    t.error(err)
+
+    sget({
+      method: 'GET',
+      url: 'http://localhost:' + fastify.server.address().port
+    }, (err, response, body) => {
+      t.error(err)
+      t.strictEqual(response.statusCode, 200)
+      t.strictEqual(response.headers['content-length'], '' + body.length)
+      t.strictEqual(response.headers['content-type'], 'text/html; charset=utf-8')
+      t.strictEqual(mustache.render(fs.readFileSync('./templates/index.html', 'utf8'), localsData), body.toString())
+      fastify.close()
+    })
+  })
+})
+
+test('reply.view for mustache engine with data-parameter and reply.locals and defaultContext', t => {
+  t.plan(6)
+  const fastify = Fastify()
+  const mustache = require('mustache')
+  const localsData = { text: 'text from locals' }
+  const contextData = { text: 'text from context' }
+  const data = { text: 'text' }
+
+  fastify.register(require('../index'), {
+    engine: {
+      mustache: mustache
+    },
+    defaultContext: contextData
+  })
+
+  fastify.addHook('preHandler', function (request, reply, done) {
+    reply.locals = localsData
+    done()
+  })
+
+  fastify.get('/', (req, reply) => {
+    reply.view('./templates/index.html', data)
+  })
+
+  fastify.listen(0, err => {
+    t.error(err)
+
+    sget({
+      method: 'GET',
+      url: 'http://localhost:' + fastify.server.address().port
+    }, (err, response, body) => {
+      t.error(err)
+      t.strictEqual(response.statusCode, 200)
+      t.strictEqual(response.headers['content-length'], '' + body.length)
+      t.strictEqual(response.headers['content-type'], 'text/html; charset=utf-8')
+      t.strictEqual(mustache.render(fs.readFileSync('./templates/index.html', 'utf8'), data), body.toString())
+      fastify.close()
+    })
+  })
+})
+
 test('reply.view with mustache engine and html-minifier', t => {
   t.plan(6)
   const fastify = Fastify()

--- a/test/test-nunjucks.js
+++ b/test/test-nunjucks.js
@@ -24,12 +24,11 @@ test('reply.view with nunjucks engine and custom templates folder', t => {
   fastify.register(require('../index'), {
     engine: {
       nunjucks: nunjucks
-    },
-    templates: 'templates'
+    }
   })
 
   fastify.get('/', (req, reply) => {
-    reply.view('./index.njk', data)
+    reply.view('./templates/index.njk', data)
   })
 
   fastify.listen(0, err => {
@@ -43,8 +42,7 @@ test('reply.view with nunjucks engine and custom templates folder', t => {
       t.strictEqual(response.statusCode, 200)
       t.strictEqual(response.headers['content-length'], '' + body.length)
       t.strictEqual(response.headers['content-type'], 'text/html; charset=utf-8')
-      // Global Nunjucks templates dir changed here.
-      t.strictEqual(nunjucks.render('./index.njk', data), body.toString())
+      t.strictEqual(nunjucks.render('./templates/index.njk', data), body.toString())
       fastify.close()
     })
   })
@@ -60,12 +58,11 @@ test('reply.view for nunjucks engine without data-parameter but defaultContext',
     engine: {
       nunjucks: nunjucks
     },
-    templates: 'templates',
     defaultContext: data
   })
 
   fastify.get('/', (req, reply) => {
-    reply.view('./index.njk')
+    reply.view('./templates/index.njk')
   })
 
   fastify.listen(0, err => {
@@ -79,8 +76,7 @@ test('reply.view for nunjucks engine without data-parameter but defaultContext',
       t.strictEqual(response.statusCode, 200)
       t.strictEqual(response.headers['content-length'], '' + body.length)
       t.strictEqual(response.headers['content-type'], 'text/html; charset=utf-8')
-      // Global Nunjucks templates dir changed here.
-      t.strictEqual(nunjucks.render('./index.njk', data), body.toString())
+      t.strictEqual(nunjucks.render('./templates/index.njk', data), body.toString())
       fastify.close()
     })
   })
@@ -94,12 +90,11 @@ test('reply.view for nunjucks engine without data-parameter and without defaultC
   fastify.register(require('../index'), {
     engine: {
       nunjucks: nunjucks
-    },
-    templates: 'templates'
+    }
   })
 
   fastify.get('/', (req, reply) => {
-    reply.view('./index.njk')
+    reply.view('./templates/index.njk')
   })
 
   fastify.listen(0, err => {
@@ -113,8 +108,165 @@ test('reply.view for nunjucks engine without data-parameter and without defaultC
       t.strictEqual(response.statusCode, 200)
       t.strictEqual(response.headers['content-length'], '' + body.length)
       t.strictEqual(response.headers['content-type'], 'text/html; charset=utf-8')
-      // Global Nunjucks templates dir changed here.
-      t.strictEqual(nunjucks.render('./index.njk'), body.toString())
+      t.strictEqual(nunjucks.render('./templates/index.njk'), body.toString())
+      fastify.close()
+    })
+  })
+})
+
+test('reply.view for nunjucks engine without data-parameter and defaultContext but with reply.locals', t => {
+  t.plan(6)
+  const fastify = Fastify()
+  const nunjucks = require('nunjucks')
+  const localsData = { text: 'text from locals' }
+
+  fastify.register(require('../index'), {
+    engine: {
+      nunjucks: nunjucks
+    }
+  })
+
+  fastify.addHook('preHandler', function (request, reply, done) {
+    reply.locals = localsData
+    done()
+  })
+
+  fastify.get('/', (req, reply) => {
+    reply.view('./templates/index.njk')
+  })
+
+  fastify.listen(0, err => {
+    t.error(err)
+
+    sget({
+      method: 'GET',
+      url: 'http://localhost:' + fastify.server.address().port
+    }, (err, response, body) => {
+      t.error(err)
+      t.strictEqual(response.statusCode, 200)
+      t.strictEqual(response.headers['content-length'], '' + body.length)
+      t.strictEqual(response.headers['content-type'], 'text/html; charset=utf-8')
+      t.strictEqual(nunjucks.render('./templates/index.njk', localsData), body.toString())
+      fastify.close()
+    })
+  })
+})
+
+test('reply.view for nunjucks engine without defaultContext but with reply.locals and data-parameter', t => {
+  t.plan(6)
+  const fastify = Fastify()
+  const nunjucks = require('nunjucks')
+  const localsData = { text: 'text from locals' }
+  const data = { text: 'text' }
+
+  fastify.register(require('../index'), {
+    engine: {
+      nunjucks: nunjucks
+    }
+  })
+
+  fastify.addHook('preHandler', function (request, reply, done) {
+    reply.locals = localsData
+    done()
+  })
+
+  fastify.get('/', (req, reply) => {
+    reply.view('./templates/index.njk', data)
+  })
+
+  fastify.listen(0, err => {
+    t.error(err)
+
+    sget({
+      method: 'GET',
+      url: 'http://localhost:' + fastify.server.address().port
+    }, (err, response, body) => {
+      t.error(err)
+      t.strictEqual(response.statusCode, 200)
+      t.strictEqual(response.headers['content-length'], '' + body.length)
+      t.strictEqual(response.headers['content-type'], 'text/html; charset=utf-8')
+      t.strictEqual(nunjucks.render('./templates/index.njk', data), body.toString())
+      fastify.close()
+    })
+  })
+})
+
+test('reply.view for nunjucks engine without data-parameter but with reply.locals and defaultContext', t => {
+  t.plan(6)
+  const fastify = Fastify()
+  const nunjucks = require('nunjucks')
+  const localsData = { text: 'text from locals' }
+  const contextData = { text: 'text from context' }
+
+  fastify.register(require('../index'), {
+    engine: {
+      nunjucks: nunjucks
+    },
+    defaultContext: contextData
+  })
+
+  fastify.addHook('preHandler', function (request, reply, done) {
+    reply.locals = localsData
+    done()
+  })
+
+  fastify.get('/', (req, reply) => {
+    reply.view('./templates/index.njk')
+  })
+
+  fastify.listen(0, err => {
+    t.error(err)
+
+    sget({
+      method: 'GET',
+      url: 'http://localhost:' + fastify.server.address().port
+    }, (err, response, body) => {
+      t.error(err)
+      t.strictEqual(response.statusCode, 200)
+      t.strictEqual(response.headers['content-length'], '' + body.length)
+      t.strictEqual(response.headers['content-type'], 'text/html; charset=utf-8')
+      t.strictEqual(nunjucks.render('./templates/index.njk', localsData), body.toString())
+      fastify.close()
+    })
+  })
+})
+
+test('reply.view for nunjucks engine with data-parameter and reply.locals and defaultContext', t => {
+  t.plan(6)
+  const fastify = Fastify()
+  const nunjucks = require('nunjucks')
+  const localsData = { text: 'text from locals' }
+  const contextData = { text: 'text from context' }
+  const data = { text: 'text' }
+
+  fastify.register(require('../index'), {
+    engine: {
+      nunjucks: nunjucks
+    },
+    defaultContext: contextData
+  })
+
+  fastify.addHook('preHandler', function (request, reply, done) {
+    reply.locals = localsData
+    done()
+  })
+
+  fastify.get('/', (req, reply) => {
+    reply.view('./templates/index.njk', data)
+  })
+
+  fastify.listen(0, err => {
+    t.error(err)
+
+    sget({
+      method: 'GET',
+      url: 'http://localhost:' + fastify.server.address().port
+    }, (err, response, body) => {
+      t.error(err)
+      t.strictEqual(response.statusCode, 200)
+      t.strictEqual(response.headers['content-length'], '' + body.length)
+      t.strictEqual(response.headers['content-type'], 'text/html; charset=utf-8')
+      t.strictEqual(nunjucks.render('./templates/index.njk', data), body.toString())
       fastify.close()
     })
   })

--- a/test/test-pug.js
+++ b/test/test-pug.js
@@ -181,6 +181,164 @@ test('reply.view with pug engine and defaultContext', t => {
   })
 })
 
+test('reply.view for pug engine without data-parameter and defaultContext but with reply.locals', t => {
+  t.plan(6)
+  const fastify = Fastify()
+  const pug = require('pug')
+  const localsData = { text: 'text from locals' }
+
+  fastify.register(require('../index'), {
+    engine: {
+      pug: pug
+    }
+  })
+
+  fastify.addHook('preHandler', function (request, reply, done) {
+    reply.locals = localsData
+    done()
+  })
+
+  fastify.get('/', (req, reply) => {
+    reply.view('./templates/index.pug')
+  })
+
+  fastify.listen(0, err => {
+    t.error(err)
+
+    sget({
+      method: 'GET',
+      url: 'http://localhost:' + fastify.server.address().port
+    }, (err, response, body) => {
+      t.error(err)
+      t.strictEqual(response.statusCode, 200)
+      t.strictEqual(response.headers['content-length'], '' + body.length)
+      t.strictEqual(response.headers['content-type'], 'text/html; charset=utf-8')
+      t.strictEqual(pug.render(fs.readFileSync('./templates/index.pug', 'utf8'), localsData), body.toString())
+      fastify.close()
+    })
+  })
+})
+
+test('reply.view for pug engine without defaultContext but with reply.locals and data-parameter', t => {
+  t.plan(6)
+  const fastify = Fastify()
+  const pug = require('pug')
+  const localsData = { text: 'text from locals' }
+  const data = { text: 'text' }
+
+  fastify.register(require('../index'), {
+    engine: {
+      pug: pug
+    }
+  })
+
+  fastify.addHook('preHandler', function (request, reply, done) {
+    reply.locals = localsData
+    done()
+  })
+
+  fastify.get('/', (req, reply) => {
+    reply.view('./templates/index.pug', data)
+  })
+
+  fastify.listen(0, err => {
+    t.error(err)
+
+    sget({
+      method: 'GET',
+      url: 'http://localhost:' + fastify.server.address().port
+    }, (err, response, body) => {
+      t.error(err)
+      t.strictEqual(response.statusCode, 200)
+      t.strictEqual(response.headers['content-length'], '' + body.length)
+      t.strictEqual(response.headers['content-type'], 'text/html; charset=utf-8')
+      t.strictEqual(pug.render(fs.readFileSync('./templates/index.pug', 'utf8'), data), body.toString())
+      fastify.close()
+    })
+  })
+})
+
+test('reply.view for pug engine without data-parameter but with reply.locals and defaultContext', t => {
+  t.plan(6)
+  const fastify = Fastify()
+  const pug = require('pug')
+  const localsData = { text: 'text from locals' }
+  const contextData = { text: 'text from context' }
+
+  fastify.register(require('../index'), {
+    engine: {
+      pug: pug
+    },
+    defaultContext: contextData
+  })
+
+  fastify.addHook('preHandler', function (request, reply, done) {
+    reply.locals = localsData
+    done()
+  })
+
+  fastify.get('/', (req, reply) => {
+    reply.view('./templates/index.pug')
+  })
+
+  fastify.listen(0, err => {
+    t.error(err)
+
+    sget({
+      method: 'GET',
+      url: 'http://localhost:' + fastify.server.address().port
+    }, (err, response, body) => {
+      t.error(err)
+      t.strictEqual(response.statusCode, 200)
+      t.strictEqual(response.headers['content-length'], '' + body.length)
+      t.strictEqual(response.headers['content-type'], 'text/html; charset=utf-8')
+      t.strictEqual(pug.render(fs.readFileSync('./templates/index.pug', 'utf8'), localsData), body.toString())
+      fastify.close()
+    })
+  })
+})
+
+test('reply.view for pug engine with data-parameter and reply.locals and defaultContext', t => {
+  t.plan(6)
+  const fastify = Fastify()
+  const pug = require('pug')
+  const localsData = { text: 'text from locals' }
+  const contextData = { text: 'text from context' }
+  const data = { text: 'text' }
+
+  fastify.register(require('../index'), {
+    engine: {
+      pug: pug
+    },
+    defaultContext: contextData
+  })
+
+  fastify.addHook('preHandler', function (request, reply, done) {
+    reply.locals = localsData
+    done()
+  })
+
+  fastify.get('/', (req, reply) => {
+    reply.view('./templates/index.pug', data)
+  })
+
+  fastify.listen(0, err => {
+    t.error(err)
+
+    sget({
+      method: 'GET',
+      url: 'http://localhost:' + fastify.server.address().port
+    }, (err, response, body) => {
+      t.error(err)
+      t.strictEqual(response.statusCode, 200)
+      t.strictEqual(response.headers['content-length'], '' + body.length)
+      t.strictEqual(response.headers['content-type'], 'text/html; charset=utf-8')
+      t.strictEqual(pug.render(fs.readFileSync('./templates/index.pug', 'utf8'), data), body.toString())
+      fastify.close()
+    })
+  })
+})
+
 test('reply.view with pug engine and html-minifier', t => {
   t.plan(6)
   const fastify = Fastify()

--- a/test/test-twig.js
+++ b/test/test-twig.js
@@ -195,6 +195,176 @@ test('reply.view with twig engine and defaultContext', t => {
   })
 })
 
+test('reply.view for twig engine without data-parameter and defaultContext but with reply.locals', t => {
+  t.plan(7)
+  const fastify = Fastify()
+  const Twig = require('twig')
+  const localsData = { text: 'text from locals' }
+
+  fastify.register(require('../index'), {
+    engine: {
+      twig: Twig
+    }
+  })
+
+  fastify.addHook('preHandler', function (request, reply, done) {
+    reply.locals = localsData
+    done()
+  })
+
+  fastify.get('/', (req, reply) => {
+    reply.view('./templates/index.twig')
+  })
+
+  fastify.listen(0, err => {
+    t.error(err)
+
+    sget({
+      method: 'GET',
+      url: 'http://localhost:' + fastify.server.address().port
+    }, (err, response, body) => {
+      t.error(err)
+      t.strictEqual(response.statusCode, 200)
+      t.strictEqual(response.headers['content-length'], '' + body.length)
+      t.strictEqual(response.headers['content-type'], 'text/html; charset=utf-8')
+      Twig.renderFile('./templates/index.twig', localsData, (err, html) => {
+        t.error(err)
+        t.strictEqual(html, body.toString())
+      })
+      fastify.close()
+    })
+  })
+})
+
+test('reply.view for twig engine without defaultContext but with reply.locals and data-parameter', t => {
+  t.plan(7)
+  const fastify = Fastify()
+  const Twig = require('twig')
+  const localsData = { text: 'text from locals' }
+  const data = { text: 'text' }
+
+  fastify.register(require('../index'), {
+    engine: {
+      twig: Twig
+    }
+  })
+
+  fastify.addHook('preHandler', function (request, reply, done) {
+    reply.locals = localsData
+    done()
+  })
+
+  fastify.get('/', (req, reply) => {
+    reply.view('./templates/index.twig', data)
+  })
+
+  fastify.listen(0, err => {
+    t.error(err)
+
+    sget({
+      method: 'GET',
+      url: 'http://localhost:' + fastify.server.address().port
+    }, (err, response, body) => {
+      t.error(err)
+      t.strictEqual(response.statusCode, 200)
+      t.strictEqual(response.headers['content-length'], '' + body.length)
+      t.strictEqual(response.headers['content-type'], 'text/html; charset=utf-8')
+      Twig.renderFile('./templates/index.twig', data, (err, html) => {
+        t.error(err)
+        t.strictEqual(html, body.toString())
+      })
+      fastify.close()
+    })
+  })
+})
+
+test('reply.view for twig engine without data-parameter but with reply.locals and defaultContext', t => {
+  t.plan(7)
+  const fastify = Fastify()
+  const Twig = require('twig')
+  const localsData = { text: 'text from locals' }
+  const contextData = { text: 'text from context' }
+
+  fastify.register(require('../index'), {
+    engine: {
+      twig: Twig
+    },
+    defaultContext: contextData
+  })
+
+  fastify.addHook('preHandler', function (request, reply, done) {
+    reply.locals = localsData
+    done()
+  })
+
+  fastify.get('/', (req, reply) => {
+    reply.view('./templates/index.twig')
+  })
+
+  fastify.listen(0, err => {
+    t.error(err)
+
+    sget({
+      method: 'GET',
+      url: 'http://localhost:' + fastify.server.address().port
+    }, (err, response, body) => {
+      t.error(err)
+      t.strictEqual(response.statusCode, 200)
+      t.strictEqual(response.headers['content-length'], '' + body.length)
+      t.strictEqual(response.headers['content-type'], 'text/html; charset=utf-8')
+      Twig.renderFile('./templates/index.twig', localsData, (err, html) => {
+        t.error(err)
+        t.strictEqual(html, body.toString())
+      })
+      fastify.close()
+    })
+  })
+})
+
+test('reply.view for twig engine with data-parameter and reply.locals and defaultContext', t => {
+  t.plan(7)
+  const fastify = Fastify()
+  const Twig = require('twig')
+  const localsData = { text: 'text from locals' }
+  const contextData = { text: 'text from context' }
+  const data = { text: 'text' }
+
+  fastify.register(require('../index'), {
+    engine: {
+      twig: Twig
+    },
+    defaultContext: contextData
+  })
+
+  fastify.addHook('preHandler', function (request, reply, done) {
+    reply.locals = localsData
+    done()
+  })
+
+  fastify.get('/', (req, reply) => {
+    reply.view('./templates/index.twig', data)
+  })
+
+  fastify.listen(0, err => {
+    t.error(err)
+
+    sget({
+      method: 'GET',
+      url: 'http://localhost:' + fastify.server.address().port
+    }, (err, response, body) => {
+      t.error(err)
+      t.strictEqual(response.statusCode, 200)
+      t.strictEqual(response.headers['content-length'], '' + body.length)
+      t.strictEqual(response.headers['content-type'], 'text/html; charset=utf-8')
+      Twig.renderFile('./templates/index.twig', data, (err, html) => {
+        t.error(err)
+        t.strictEqual(html, body.toString())
+      })
+      fastify.close()
+    })
+  })
+})
+
 test('reply.view with twig engine and html-minifier', t => {
   t.plan(7)
   const fastify = Fastify()


### PR DESCRIPTION
I've added feature to override properties from defaultContext with ones from reply.locals.
Not all tests are updated yet, because I want someone to check implementation first.

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
