### PR TITLE
Ignore non-JS files in destinationDir

### DIFF
--- a/index.js
+++ b/index.js
@@ -218,7 +218,9 @@ function fastifyView (fastify, opts, next) {
 
     // .jst files are compiled to .js files so we need to require them
     for (const file of readdirSync(destinationDir, { withFileTypes: false })) {
-      renderer[basename(file, '.js')] = require(resolve(join(destinationDir, file)))
+      if (file.match(/\.js$/i)) {
+        renderer[basename(file, '.js')] = require(resolve(join(destinationDir, file)))
+      }
     }
     if (Object.keys(renderer).length === 0) {
       this.log.warn(`WARN: no template found in ${templatesDir}`)


### PR DESCRIPTION
Some operating systems silently and automatically create "hidden files" inside new directories. So, for example on Mac OS, the destinationDir can have a `.DS_Store` file appear within it from the system. The code in point-of-view that tries to `require` compiled templates should ignore these, and indeed any files that do not end in `.js`.
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [ ] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
