### PR TITLE
Support load template from memory for marko template engine

### DIFF
--- a/example-marko.js
+++ b/example-marko.js
@@ -1,0 +1,56 @@
+'use strict'
+
+const fastify = require('fastify')()
+const resolve = require('path').resolve
+const templatesFolder = 'templates'
+const marko = require('marko')
+
+const data = { text: 'marko' }
+
+const templateSrc = `
+<!DOCTYPE html>
+<html lang="en">
+  <head></head>
+  <body>
+    <p>\${data.text} from memory</p>
+  </body>
+</html>
+`
+
+// To ask marko compile template from pre-loaded template for example from a web editor
+// Pass the template as property templateSrc of opts
+// The page parameter still should be passed and its path should exist in so that marko engine
+// could lookup components along the parent path.
+
+const opts = { templateSrc }
+
+fastify.register(require('./index'), {
+  engine: {
+    marko
+  },
+  includeViewExtension: true,
+  templates: templatesFolder,
+  options: {
+    filename: resolve(templatesFolder)
+  },
+  charset: 'utf-8' // sample usage, but specifying the same value already used as default
+})
+
+// Load template from memory
+// Web page should show text: marko from memory
+
+fastify.get('/mem', (req, reply) => {
+  reply.view('mem', data, opts)
+})
+
+// Load template from file system
+// Web page should show text: marko
+
+fastify.get('/file', (req, reply) => {
+  reply.view('index', data)
+})
+
+fastify.listen(3000, err => {
+  if (err) throw err
+  console.log(`server listening on ${fastify.server.address().port}`)
+})

--- a/index.js
+++ b/index.js
@@ -342,7 +342,11 @@ function fastifyView (fastify, opts, next) {
     // append view extension
     page = getPage(page, type)
 
-    const template = engine.load(join(templatesDir, page))
+    // Support compile template from memory
+    // opts.templateSrc : string - pre-loaded template source
+    // even to load from memory, a page parameter still should be provided and the parent path should exist for the loader to search components along the path.
+
+    const template = opts && opts.templateSrc ? engine.load(join(templatesDir, page), opts.templateSrc) : engine.load(join(templatesDir, page))
 
     if (opts && opts.stream) {
       if (typeof options.useHtmlMinifyStream === 'function') {

--- a/test/test-marko.js
+++ b/test/test-marko.js
@@ -442,3 +442,48 @@ test('fastify.view with marko engine', t => {
     })
   })
 })
+
+test('fastify.view to load template from memory with marko engine', t => {
+  t.plan(6)
+  const fastify = Fastify()
+  const marko = require('marko')
+  const data = { text: 'marko' }
+  const templateSrc = `
+<!DOCTYPE html>
+<html lang="en">
+  <head></head>
+  <body>
+    <p>\${data.text}</p>
+  </body>
+</html>
+`
+
+  const opts = { templateSrc }
+
+  fastify.register(require('../index'), {
+    engine: {
+      marko: marko
+    }
+  })
+
+  fastify.ready(err => {
+    t.error(err)
+
+    fastify.view('templates/index.marko', data, opts, (err, compiled) => {
+      t.error(err)
+      const markoLoaded = marko.load('./templates/index.marko', opts).renderToString(data)
+
+      t.strictEqual(markoLoaded, compiled)
+      fastify.ready(err => {
+        t.error(err)
+
+        fastify.view('templates/index.marko', data, (err, compiled) => {
+          t.error(err)
+          const markoLoaded = marko.load('./templates/index.marko', opts).renderToString(data)
+          t.strictEqual(markoLoaded, compiled)
+          fastify.close()
+        })
+      })
+    })
+  })
+})


### PR DESCRIPTION
Marko template engine's loader supports loading template from memory, which is important for the use case of pre-loading template from central repository like AWS, edited through web editor.

This pull request supports this use case by testing if `templateSrc` exists in `opts` and pass it to `marko` loader if it exists.
Developer using this model should pass pre-loaded template source as `templateSrc` property of `opts`.

The `path` for template page should still be provided and the folder should still exist or be created for marko loader's search of components. It has been tested with the sample `fastify` integration code of `marko`.

`npm run test` result:

```
Suites:   13 passed, 13 of 13 completed
Asserts:  1027 passed, of 1027
Time:     4s
```
File               |  % Stmts | % Branch |  % Funcs |  % Lines | Uncovered Line #s |
-------------------|----------|----------|----------|----------|-------------------|
All files          |    81.74 |    75.61 |    90.91 |    83.54 |                   |
 point-of-view     |    82.97 |    78.26 |    95.92 |    83.44 |                   |
  index.js         |    82.97 |    78.26 |    95.92 |    83.44 |... 59,560,562,578 |
 point-of-view/out |    58.82 |     37.5 |       50 |     87.5 |                   |
  testjst.js       |    58.82 |     37.5 |       50 |     87.5 |                 8 |
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
