### PR TITLE
fix(Eta): cache instance provided through options is ignored and replaced with the default one

### DIFF
--- a/index.js
+++ b/index.js
@@ -525,7 +525,7 @@ function fastifyView (fastify, opts, next) {
 
     lru.define = lru.set
     engine.configure({
-      templates: lru
+      templates: options.templates ? options.templates : lru
     })
 
     const config = Object.assign({ views: templatesDir }, options)

--- a/test/test-eta.js
+++ b/test/test-eta.js
@@ -855,6 +855,7 @@ test('fastify.view with eta engine and custom cache', t => {
   const pseudoCache = {
     cache: {},
     get: function (k) {
+      t.pass('the cache is set')
       return this.cache[k]
     },
     define: function (k, v) {

--- a/test/test-eta.js
+++ b/test/test-eta.js
@@ -842,3 +842,69 @@ test('fastify.view with eta engine and callback in production mode', t => {
     })
   })
 })
+
+test('fastify.view with eta engine and custom cache', t => {
+  t.plan(7)
+  const fastify = Fastify()
+
+  const tplPath = 'templates/index.eta'
+  const tplAbsPath = path.normalize(path.join(process.cwd(), '/', tplPath))
+  const data = { text: 'text' }
+
+  // Custom cache
+  const pseudoCache = {
+    cache: {},
+    get: function (k) {
+      return this.cache[k]
+    },
+    define: function (k, v) {
+      this.cache[k] = v
+    }
+  }
+
+  const etaOptions = {
+    cache: true,
+    templates: pseudoCache
+  }
+
+  eta.configure(etaOptions)
+
+  fastify.register(pointOfView, {
+    engine: {
+      eta: eta
+    },
+    options: etaOptions
+  })
+
+  // pre-cache
+  const tplFn = eta.loadFile(tplAbsPath, { filename: tplAbsPath })
+
+  fastify.get('/', (req, reply) => {
+    try {
+      const res = reply.view(tplPath, data)
+      t.strictEqual(eta.config.templates, pseudoCache,
+        'Cache instance should be equal to the pre-defined one')
+      t.notStrictEqual(eta.config.templates.get(tplAbsPath), undefined,
+        'Template should be pre-cached')
+      return res
+    } catch (e) {
+      t.error(e)
+    }
+  })
+
+  fastify.listen(0, err => {
+    t.error(err)
+    sget({
+      method: 'GET',
+      url: 'http://localhost:' + fastify.server.address().port
+    }, (err, response, body) => {
+      t.error(err)
+      t.strictEqual(response.statusCode, 200, 'Response should be 200')
+      tplFn(data, eta.config, (err, str) => {
+        t.error(err)
+        t.strictEqual(str, body.toString(), 'Route should return the same result as cached template function')
+      })
+      fastify.close()
+    })
+  })
+})

--- a/test/test-eta.js
+++ b/test/test-eta.js
@@ -844,7 +844,7 @@ test('fastify.view with eta engine and callback in production mode', t => {
 })
 
 test('fastify.view with eta engine and custom cache', t => {
-  t.plan(8)
+  t.plan(9)
   const fastify = Fastify()
 
   const tplPath = 'templates/index.eta'

--- a/test/test-eta.js
+++ b/test/test-eta.js
@@ -844,7 +844,7 @@ test('fastify.view with eta engine and callback in production mode', t => {
 })
 
 test('fastify.view with eta engine and custom cache', t => {
-  t.plan(7)
+  t.plan(8)
   const fastify = Fastify()
 
   const tplPath = 'templates/index.eta'

--- a/test/test-eta.js
+++ b/test/test-eta.js
@@ -848,7 +848,7 @@ test('fastify.view with eta engine and custom cache', t => {
   const fastify = Fastify()
 
   const tplPath = 'templates/index.eta'
-  const tplAbsPath = path.normalize(path.join(process.cwd(), '/', tplPath))
+  const tplAbsPath = path.resolve(tplPath)
   const data = { text: 'text' }
 
   // Custom cache


### PR DESCRIPTION
Fix for Eta template engine issue: cache instance were always replaced with the default one

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
