### PR TITLE
Add name to plugin (#1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -286,6 +286,14 @@ fastify.addHook('preHandler', function (request, reply, done) {
 ```
 Properties from `reply.locals` will override those from `defaultContext`, but not from `data` parameter provided to `reply.view(template, data)` function.
 
+To require `point-of-view` as a dependency to a [fastify-plugin](https://github.com/fastify/fastify-plugin) add the name `point-of-view` to the depencencies array in the [plugin's opts](https://github.com/fastify/fastify-plugin#dependencies).
+
+```
+  {
+    dependencies: ['point-of-view] 
+  }
+```
+
 <a name="note"></a>
 ## Note
 

--- a/README.md
+++ b/README.md
@@ -286,12 +286,12 @@ fastify.addHook('preHandler', function (request, reply, done) {
 ```
 Properties from `reply.locals` will override those from `defaultContext`, but not from `data` parameter provided to `reply.view(template, data)` function.
 
-To require `point-of-view` as a dependency to a [fastify-plugin](https://github.com/fastify/fastify-plugin) add the name `point-of-view` to the dependencies array in the [plugin's opts](https://github.com/fastify/fastify-plugin#dependencies).
+To require `point-of-view` as a dependency to a [fastify-plugin](https://github.com/fastify/fastify-plugin), add the name `point-of-view` to the dependencies array in the [plugin's opts](https://github.com/fastify/fastify-plugin#dependencies).
 
-```
-  {
-    dependencies: ['point-of-view] 
-  }
+```js
+fastify.register(myViewRendererPlugin,   {
+  dependencies: ['point-of-view']
+})
 ```
 
 <a name="note"></a>

--- a/README.md
+++ b/README.md
@@ -286,7 +286,7 @@ fastify.addHook('preHandler', function (request, reply, done) {
 ```
 Properties from `reply.locals` will override those from `defaultContext`, but not from `data` parameter provided to `reply.view(template, data)` function.
 
-To require `point-of-view` as a dependency to a [fastify-plugin](https://github.com/fastify/fastify-plugin) add the name `point-of-view` to the depencencies array in the [plugin's opts](https://github.com/fastify/fastify-plugin#dependencies).
+To require `point-of-view` as a dependency to a [fastify-plugin](https://github.com/fastify/fastify-plugin) add the name `point-of-view` to the dependencies array in the [plugin's opts](https://github.com/fastify/fastify-plugin#dependencies).
 
 ```
   {

--- a/index.js
+++ b/index.js
@@ -600,4 +600,7 @@ function fastifyView (fastify, opts, next) {
   }
 }
 
-module.exports = fp(fastifyView, { fastify: '>=3.x' })
+module.exports = fp(fastifyView, {
+  fastify: '>=3.x',
+  name: 'point-of-view'
+})

--- a/index.js
+++ b/index.js
@@ -601,6 +601,6 @@ function fastifyView (fastify, opts, next) {
 }
 
 module.exports = fp(fastifyView, {
-  fastify: '>=3.x',
+  fastify: '3.x',
   name: 'point-of-view'
 })

--- a/test/test.js
+++ b/test/test.js
@@ -174,3 +174,24 @@ test('register callback should throw if layout option provided with wrong engine
     t.is(err.message, 'Only Handlebars, EJS, and Eta support the "layout" option')
   })
 })
+
+test('plugin is registered with "point-of-view" name', t => {
+  t.plan(2)
+  const fastify = Fastify()
+
+  fastify.register(require('../index'), {
+    engine: {
+      ejs: require('ejs')
+    }
+  })
+
+  fastify.ready(err => {
+    t.error(err)
+
+    const kRegistedPlugins = Symbol.for('registered-plugin')
+    const registeredPlugins = fastify[kRegistedPlugins]
+    t.ok(registeredPlugins.find(name => name === 'point-of-view'))
+
+    fastify.close()
+  })
+})


### PR DESCRIPTION
### Summary
- Name the plugin 'point-of-view' so it can be required as a [plugin dependency](https://github.com/fastify/fastify-plugin#dependencies).
- Add instructions for requiring `point-of-view` as a plugin dependency in `README.md`.
-  Create test for name registration