### PR TITLE
Add propertyName to PointOfViewOptions interface

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -31,6 +31,7 @@ export interface PointOfViewOptions {
   layout?: string;
   root?: string;
   viewExt?: string;
+  propertyName?: string;
 }
 
 declare const pointOfView: FastifyPlugin<PointOfViewOptions>;

--- a/test/index.test-d.ts
+++ b/test/index.test-d.ts
@@ -36,4 +36,4 @@ app.listen(3000, (err, address) => {
   console.log(`server listening on ${address} ...`)
 })
 
-expectAssignable<PointOfViewOptions>({engine: {twig: require('twig') } })
+expectAssignable<PointOfViewOptions>({engine: {twig: require('twig') }, propertyName: 'mobile' })


### PR DESCRIPTION
Hey,

this PR adds the `propertyName` option to the PointOfViewOptions interface.

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
