### PR TITLE
docs: fix typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,11 +187,11 @@ fastify.get('/', (req, reply) => {
 })
 ```
 
-To configure nunjunks environment after initialisation, you can pass callback function to options:
+To configure nunjucks environment after initialisation, you can pass callback function to options:
 ```js
   options: {
     onConfigure: (env) => {
-      // do whatever you want on nunjunks env
+      // do whatever you want on nunjucks env
     }
 
   }


### PR DESCRIPTION
replace `nunjunks` to `nunjucks` in README.md

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
