### PR TITLE
Use a more appropriate type for locals

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -3,7 +3,7 @@ import { FastifyPlugin, FastifyReply, RawServerBase } from 'fastify';
 declare module "fastify" {
   interface FastifyReply {
     view(page: string, data?: object): FastifyReply;
-    locals?: object;
+    locals?: Record<string, any>;
   }
 }
 


### PR DESCRIPTION
The current type of locals, `object`, means literally `{}` with no members and typescript will prevent people adding new ones. `Record<string, any>` is more appropriate.