### PR TITLE
Removed the definition of locals from index.d.ts

### DIFF
--- a/README.md
+++ b/README.md
@@ -306,8 +306,12 @@ Typing parameters from `reply.locals` in `typescript`:
 
 ```typescript
 interface Locals {
- appVersion: string,
- assetsManifest: AssetsManifest,
+  appVersion: string,
+  isAuthorized: boolean,
+  user?: {
+    id: number
+    login: string
+  }
 }
 
 declare module 'fastify' {
@@ -315,6 +319,18 @@ declare module 'fastify' {
     locals: Partial<Locals> | undefined;
   }
 }
+
+app.addHook('onRequest',  (request, reply, done) => {
+  if (!reply.locals) {
+    reply.locals = {}
+  }
+  
+  reply.locals.isAuthorized = true;
+  reply.locals.user = {
+   id: 1,
+   login: 'Admin'
+  }
+})
 
 app.get("/data", (request, reply) => {
  if (!reply.locals) {

--- a/README.md
+++ b/README.md
@@ -302,6 +302,32 @@ fastify.addHook('preHandler', function (request, reply, done) {
 ```
 Properties from `reply.locals` will override those from `defaultContext`, but not from `data` parameter provided to `reply.view(template, data)` function.
 
+Typing parameters from `reply.locals` in `typescript`: 
+
+```typescript
+interface Locals {
+ appVersion: string,
+ assetsManifest: AssetsManifest,
+}
+
+declare module 'fastify' {
+  interface FastifyReply {
+    locals: Partial<Locals> | undefined;
+  }
+}
+
+app.get("/data", (request, reply) => {
+ if (!reply.locals) {
+  reply.locals = {}
+ }
+
+ // reply.locals.appVersion = 1 // not a valid type
+ reply.locals.appVersion = '4.14.0'
+ reply.view("/index", { text: "Sample data" });
+});
+
+```
+
 To require `point-of-view` as a dependency to a [fastify-plugin](https://github.com/fastify/fastify-plugin), add the name `point-of-view` to the dependencies array in the [plugin's opts](https://github.com/fastify/fastify-plugin#dependencies).
 
 ```js
@@ -332,3 +358,4 @@ This project is kindly sponsored by:
 ## License
 
 Licensed under [MIT](./LICENSE).
+

--- a/index.d.ts
+++ b/index.d.ts
@@ -3,7 +3,6 @@ import { FastifyPlugin, FastifyReply, RawServerBase } from 'fastify';
 declare module "fastify" {
   interface FastifyReply {
     view(page: string, data?: object): FastifyReply;
-    locals?: object;
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "example": "node example.js",
     "example-with-options": "node example-ejs-with-some-options.js",
-    "example-typescript": "npx ts-node types.test.ts",
+    "example-typescript": "npx ts-node test/index.test-d.ts",
     "test-with-snapshot": "cross-env TAP_SNAPSHOT=1 tap test/test-ejs-with-snapshot.js",
     "test": "standard && tap -J test/*.js && tsd"
   },

--- a/test/index.test-d.ts
+++ b/test/index.test-d.ts
@@ -3,6 +3,15 @@ import pointOfView, {PointOfViewOptions} from "..";
 import {expectAssignable} from "tsd";
 import * as path from "path";
 
+interface Locals {
+  appVersion: string,
+}
+
+declare module "fastify" {
+  interface FastifyReply {
+    locals: Partial<Locals> | undefined
+  }
+}
 const app = fastify();
 
 app.register(pointOfView, {
@@ -28,6 +37,12 @@ app.get("/", (request, reply) => {
 });
 
 app.get("/data", (request, reply) => {
+  if (!reply.locals) {
+    reply.locals = {}
+  }
+
+  // reply.locals.appVersion = 1 // not a valid type
+  reply.locals.appVersion = '4.14.0'
   reply.view("/index", { text: "Sample data" });
 });
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)

In practice it turned out that it is better when there are no definitions for `locals` at all. If necessary, it is easier to determine without conflicts directly in the code

```typescript
declare module 'fastify' {
  interface FastifyReply {
    locals: Partial<{ assetsManifest: AssetsManifest }> | undefined;
  }
}
```



```typescript
server.addHook('preHandler', (request: FastifyRequest, reply: FastifyReply, done: HookHandlerDoneFunction) => {
  if (typeof reply.locals === 'undefined') {
    reply.locals = {};
  }
  reply.locals.assetsManifest = assetsManifest();
    done();
});
```


