### PR TITLE
correctly scope liquidjs errors

### DIFF
--- a/index.js
+++ b/index.js
@@ -536,7 +536,9 @@ function fastifyView (fastify, opts, next) {
         }
         this.send(html)
       })
-      .catch(this.send)
+      .catch((err) => {
+        this.send(err)
+      })
   }
 
   function viewDot (renderModule) {

--- a/test/test-liquid.js
+++ b/test/test-liquid.js
@@ -458,3 +458,26 @@ test('fastify.view with liquid engine, should throw page missing', t => {
     })
   })
 })
+
+test('fastify.view with liquid engine template that does not exist errors correctly', t => {
+  t.plan(3)
+  const fastify = Fastify()
+  const { Liquid } = require('liquidjs')
+  const engine = new Liquid()
+
+  fastify.register(require('../index'), {
+    engine: {
+      liquid: engine
+    }
+  })
+
+  fastify.ready(err => {
+    t.error(err)
+
+    fastify.view('./I-Dont-Exist', {}, err => {
+      t.ok(err instanceof Error)
+      t.match(err.message, 'ENOENT')
+      fastify.close()
+    })
+  })
+})


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->
Fix for #243. When the liquidjs engine throws an error the scope of the catch block has `reply.send` as undefined. this swallows the liquidjs error. This PR fixes the scoping issue and allows liquid js errors to be sent by fastify correctly.

I'm not sure why https://github.com/fastify/point-of-view/blob/master/test/test-liquid.js#L439 doesn't catch this error. the error my code actually was getting from liquidjs was `err.message = 'ENOENT: Failed to lookup "${file}" in "${roots}"';` I added a test to check this error but I couldn't make it fail before I made the change so not sure if it really helps.

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
