### PR TITLE
Pass cache option to eta engine

### DIFF
--- a/index.js
+++ b/index.js
@@ -571,7 +571,7 @@ function fastifyView (fastify, opts, next) {
     })
 
     const config = Object.assign({
-      cache: process.env.NODE_ENV === 'production',
+      cache: prod,
       views: templatesDir
     }, options)
 

--- a/index.js
+++ b/index.js
@@ -570,7 +570,10 @@ function fastifyView (fastify, opts, next) {
       templates: options.templates ? options.templates : lru
     })
 
-    const config = Object.assign({ views: templatesDir }, options)
+    const config = Object.assign({
+      cache: process.env.NODE_ENV === 'production',
+      views: templatesDir
+    }, options)
 
     data = Object.assign({}, defaultCtx, this.locals, data)
     // Append view extension (Eta will append '.eta' by default,

--- a/test/test-eta.js
+++ b/test/test-eta.js
@@ -800,6 +800,40 @@ test('fastify.view with eta engine and callback in production mode', t => {
   })
 })
 
+test('fastify.view with eta engine in production mode should use cache', t => {
+  t.plan(1)
+
+  const fastify = Fastify()
+  const cache = {
+    cache: {},
+    get (k) {
+      if (typeof this.cache[k] !== 'undefined') {
+        t.pass()
+      }
+      return this.cache[k]
+    },
+    define (k, v) {
+      this.cache[k] = v
+    }
+  }
+
+  fastify.register(pointOfView, {
+    production: true,
+    engine: {
+      eta: eta
+    },
+    options: {
+      templates: cache
+    }
+  })
+
+  fastify.ready(async () => {
+    await fastify.view('templates/index.eta', { text: 'test' })
+    await fastify.view('templates/index.eta', { text: 'test' }) // This should trigger the cache
+    fastify.close()
+  })
+})
+
 test('fastify.view with eta engine and custom cache', t => {
   t.plan(9)
   const fastify = Fastify()


### PR DESCRIPTION
Hello maintainers,

While using this plugin with the https://github.com/eta-dev/eta template engine, I noticed that `NODE_ENV=production` never cached the templates.

After some digging I found the culprit:
* `point-of-view` never sends the `{ cache: true }` option to the `eta` engine

**This pull request solves this.**

```js
app.register(require("point-of-view"), {
  engine: {
    eta: require("eta")
  },
  options: {
    cache: true // This variable is now set by NODE_ENV=production
  }
});
```

It can also be enabled by passing `production: true` to the engine.

## Benchmark

Rendering a simple template with `NODE_ENV=production`

```js
// index.js
app.register(require("point-of-view"), {
  engine: {
    eta: require("eta")
  }
});
app.get("/", async (req, res) => {
  res.view("view", {
    items: ["a", "b", "c"]
  });
});

// view.eta
<ul class="items">
  <% for (let item of it.items) { %>
    <li><%= item %></li>
  <% } %>
</ul>
```

Performance improvements:

```
$ autocannon -c 100 -d 5 -p 10 localhost:8000

— Before:   32k requests in 5.03s,  7.4 MB read
— After:   252k requests in 5.03s, 60.4 MB read
```

## Checklist

- [x] run `npm run test`
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
