### PR TITLE
Fix include logic using EJS templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ and in ejs template files (for example templates/index.ejs) use something like:
 ```html
 <%- include('header.ejs') %>
 ```
-with a path relative to the current page, or an absolute path. Please check this example [here](https://raw.githubusercontent.com/fastify/point-of-view/c7ff7775cbc8dcf1a7194a517efbf243a74bd0be/templates/layout-with-includes.ejs)
+with a path relative to the current page, or an absolute path. Please check this example [here](./templates/layout-with-includes.ejs)
 
 To use partials in mustache you will need to pass the names and paths in the options parameter:
 ```js


### PR DESCRIPTION
This PR includes minor edits on the Readme file, related to EJS templates.
It was a little confusing how to include a partial EJS file in an EJS template.
 
The example code was fixed. Also, a link with a file example on how to use the `<%include%>` in an EJS template was added.