### PR TITLE
typescript: Add a generic type to .view

### DIFF
--- a/README.md
+++ b/README.md
@@ -339,7 +339,7 @@ app.get("/data", (request, reply) => {
 
  // reply.locals.appVersion = 1 // not a valid type
  reply.locals.appVersion = '4.14.0'
- reply.view("/index", { text: "Sample data" });
+ reply.view<{ text: string; }>("/index", { text: "Sample data" });
 });
 
 ```

--- a/index.d.ts
+++ b/index.d.ts
@@ -2,7 +2,8 @@ import { FastifyPlugin, FastifyReply, RawServerBase } from 'fastify';
 
 declare module "fastify" {
   interface FastifyReply {
-    view<T = object>(page: string, data?: T): FastifyReply;
+    view<T extends { [key: string]: any; }>(page: string, data: T): FastifyReply;
+    view(page: string, data?: object): FastifyReply;
   }
 }
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -2,7 +2,7 @@ import { FastifyPlugin, FastifyReply, RawServerBase } from 'fastify';
 
 declare module "fastify" {
   interface FastifyReply {
-    view(page: string, data?: object): FastifyReply;
+    view<T = object>(page: string, data?: T): FastifyReply;
   }
 }
 

--- a/test/index.test-d.ts
+++ b/test/index.test-d.ts
@@ -1,6 +1,6 @@
 import fastify from "fastify";
-import pointOfView, {PointOfViewOptions} from "..";
-import {expectAssignable} from "tsd";
+import pointOfView, { PointOfViewOptions } from "..";
+import { expectAssignable } from "tsd";
 import * as path from "path";
 
 interface Locals {
@@ -46,9 +46,19 @@ app.get("/data", (request, reply) => {
   reply.view("/index", { text: "Sample data" });
 });
 
+app.get("/dataTyped", (request, reply) => {
+  if (!reply.locals) {
+    reply.locals = {}
+  }
+
+  // reply.locals.appVersion = 1 // not a valid type
+  reply.locals.appVersion = '4.14.0'
+  reply.view<{ text: string; }>("/index", { text: "Sample data" });
+});
+
 app.listen(3000, (err, address) => {
   if (err) throw err
   console.log(`server listening on ${address} ...`)
 })
 
-expectAssignable<PointOfViewOptions>({engine: {twig: require('twig') }, propertyName: 'mobile' })
+expectAssignable<PointOfViewOptions>({ engine: { twig: require('twig') }, propertyName: 'mobile' })


### PR DESCRIPTION
I missed the ability to add typings to the view data-parameter. So with this change, it is possible to provide view a type, as I would expect.

This change is non breaking.

So what does it do exactly? 

If you provide a type, which has to be an Object-Interface, it makes the data-parameter mandatory and the provided data has to be of shape of that interface. So if you change the interface and miss to adapt the change in the view then typescript screams at you :).

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
