### PR TITLE
Create a precise cache key for partials for LRU

### DIFF
--- a/index.js
+++ b/index.js
@@ -221,9 +221,9 @@ function fastifyView (fastify, opts, next) {
   function getPartialsCacheKey (page, partials, requestedPath) {
     let cacheKey = page
 
-    Object.keys(partials).forEach(function (key) {
+    for (const key of Object.keys(partials)) {
       cacheKey += `|${key}:${partials[key]}`
-    })
+    }
 
     cacheKey += `|${requestedPath}-Partials`
 

--- a/templates/partial-1.mustache
+++ b/templates/partial-1.mustache
@@ -1,0 +1,1 @@
+Partial 1 - b4d932b9-4baa-4c99-8d14-d45411b9361e

--- a/templates/partial-2.mustache
+++ b/templates/partial-2.mustache
@@ -1,0 +1,1 @@
+Partial 2 - fdab0fe2-6dab-4429-ae9f-dfcb791d1d3d

--- a/test/test-handlebars.js
+++ b/test/test-handlebars.js
@@ -725,10 +725,10 @@ test('reply.view with handlebars engine with partials in production mode should 
     hashlru: function () {
       return {
         get: (key) => {
-          t.equal(key, 'handlebars-Partials')
+          t.equal(key, 'handlebars|body:./templates/body.hbs|null-Partials')
         },
         set: (key, value) => {
-          t.equal(key, 'handlebars-Partials')
+          t.equal(key, 'handlebars|body:./templates/body.hbs|null-Partials')
           t.strictSame(value, { body: fs.readFileSync('./templates/body.hbs', 'utf8') })
         }
       }


### PR DESCRIPTION
While using `point-of-view` I discovered a bug in the cache key generation for partials.

A minimal, reproducible test case has been created in https://github.com/mroderick/point-of-view-bug.

This PR fixes that bug.

#### Background

The cache key has to consider `page`, `partials` and `requestedPath` to be usable. Ignoring any of these values will result in a key that is too broad, which will result in invalid cache hits.

Note: because `requestedPath` is used for determining whether
minification should be used on the content, it also has to be used in
the cache key.

As below

```js
if (useHtmlMinification(globalOptions, requestedPath)) {
  data = globalOptions.useHtmlMinifier.minify(data, globalOptions.htmlMinifierOptions || {})
}
```

#### Before

| variable | value |
|----------|-------|
| page     | /templates/index.mustache |
| partials | { content: '/templates/some-partial.mustache' } |
| requestedPath | /some-path |

Would result in a cache key of `/templates/index.mustache-Partials`,
which completely ignores the partials and the requested path

If the next request would use the same template with different partials,
it would get the same cache key, and thus the partials from the first request.

#### After

| variable | value |
|----------|-------|
| page     | /templates/index.mustache |
| partials | { content: '/templates/some-partial.mustache' } |
| requestedPath | /some-path |

Would result in a cache key of
`/templates/index.mustache|content:/templates/some-partial.mustache|/some-path-Partials`,
which clearly uses `page`, `partials` and `requestedPath` for generating
the key.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
