### PR TITLE
perf: setup nunjucks environment on load rather than per request

### DIFF
--- a/index.js
+++ b/index.js
@@ -54,6 +54,7 @@ function fastifyView (fastify, opts, next) {
   }
 
   const dotRender = type === 'dot' ? viewDot.call(fastify, preProcessDot.call(fastify, templatesDir, globalOptions)) : null
+  const nunjucksEnv = type === 'nunjucks' ? engine.configure(templatesDir, globalOptions) : null
 
   const renders = {
     ejs: withLayout(viewEjs, globalLayoutFileName),
@@ -399,14 +400,13 @@ function fastifyView (fastify, opts, next) {
       this.send(new Error('Missing page'))
       return
     }
-    const env = engine.configure(templatesDir, globalOptions)
     if (typeof globalOptions.onConfigure === 'function') {
-      globalOptions.onConfigure(env)
+      globalOptions.onConfigure(nunjucksEnv)
     }
     data = Object.assign({}, defaultCtx, this.locals, data)
     // Append view extension.
     page = getPage(page, 'njk')
-    env.render(join(templatesDir, page), data, (err, html) => {
+    nunjucksEnv.render(join(templatesDir, page), data, (err, html) => {
       const requestedPath = getRequestedPath(this)
       if (err) return this.send(err)
       if (useHtmlMinification(globalOptions, requestedPath)) {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

Hi,

I've just started playing around with fastify & nunjucks as I'd like to use it for a project, but noticed the performance seemed slow. Had a poke around and point-of-view is setting up the nunjucks environment on each request, which is expensive, so I've made a change to set it up on load.

Here are some before and after autocannon numbers for a simple fastify-cli generated project, rendering a basic nunjucks view:

```
npx autocannon -c 100 -d 10 -p 10 http://localhost:3000/hello
```

## Before
```
┌─────────┬────────┬─────────┬─────────┬─────────┬────────────┬────────────┬─────────┐
│ Stat    │ 2.5%   │ 50%     │ 97.5%   │ 99%     │ Avg        │ Stdev      │ Max     │
├─────────┼────────┼─────────┼─────────┼─────────┼────────────┼────────────┼─────────┤
│ Latency │ 560 ms │ 4442 ms │ 7532 ms │ 7635 ms │ 4098.81 ms │ 1979.55 ms │ 7684 ms │
└─────────┴────────┴─────────┴─────────┴─────────┴────────────┴────────────┴─────────┘
┌───────────┬────────┬────────┬────────┬─────────┬────────┬────────┬────────┐
│ Stat      │ 1%     │ 2.5%   │ 50%    │ 97.5%   │ Avg    │ Stdev  │ Min    │
├───────────┼────────┼────────┼────────┼─────────┼────────┼────────┼────────┤
│ Req/Sec   │ 90     │ 90     │ 140    │ 180     │ 135    │ 24.24  │ 90     │
├───────────┼────────┼────────┼────────┼─────────┼────────┼────────┼────────┤
│ Bytes/Sec │ 604 kB │ 604 kB │ 940 kB │ 1.21 MB │ 906 kB │ 163 kB │ 604 kB │
└───────────┴────────┴────────┴────────┴─────────┴────────┴────────┴────────┘
3k requests in 10.1s, 9.06 MB read
171 errors (150 timeouts)
```

## After
```
┌─────────┬────────┬────────┬────────┬─────────┬───────────┬───────────┬─────────┐
│ Stat    │ 2.5%   │ 50%    │ 97.5%  │ 99%     │ Avg       │ Stdev     │ Max     │
├─────────┼────────┼────────┼────────┼─────────┼───────────┼───────────┼─────────┤
│ Latency │ 186 ms │ 287 ms │ 634 ms │ 1091 ms │ 337.51 ms │ 145.01 ms │ 1248 ms │
└─────────┴────────┴────────┴────────┴─────────┴───────────┴───────────┴─────────┘
┌───────────┬─────────┬─────────┬─────────┬───────┬─────────┬─────────┬─────────┐
│ Stat      │ 1%      │ 2.5%    │ 50%     │ 97.5% │ Avg     │ Stdev   │ Min     │
├───────────┼─────────┼─────────┼─────────┼───────┼─────────┼─────────┼─────────┤
│ Req/Sec   │ 1260    │ 1260    │ 2491    │ 4323  │ 2916.3  │ 955.13  │ 1260    │
├───────────┼─────────┼─────────┼─────────┼───────┼─────────┼─────────┼─────────┤
│ Bytes/Sec │ 8.46 MB │ 8.46 MB │ 16.7 MB │ 29 MB │ 19.6 MB │ 6.41 MB │ 8.45 MB │
└───────────┴─────────┴─────────┴─────────┴───────┴─────────┴─────────┴─────────┘
30k requests in 10.06s, 196 MB read
```

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
