### PR TITLE
feat: allow passing array of template paths for nunjucks engine

### DIFF
--- a/README.md
+++ b/README.md
@@ -333,6 +333,20 @@ fastify.get("/", (req, reply) => {
 
 ### Nunjucks
 
+You can load templates from multiple paths when using the nunjucks engine:
+
+```js
+fastify.register(require("point-of-view"), {
+  engine: {
+    nunjucks: require("nunjucks"),
+  },
+  templates: [
+    "node_modules/shared-components",
+    "views",
+  ],
+});
+```
+
 To configure nunjucks environment after initialisation, you can pass callback function to options:
 
 ```js
@@ -393,7 +407,7 @@ fastify.get("/", (req, reply) => {
 });
 ```
 
-<!--- 
+<!---
 // This seems a bit random given that there was no mention of typescript before.
 ### Typing
 

--- a/templates/nunjucks-layout/layout.njk
+++ b/templates/nunjucks-layout/layout.njk
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html lang="en" dir="ltr">
+  <head>
+    <meta charset="utf-8">
+    <title></title>
+  </head>
+  <body>
+    {% block content %}{% endblock %}
+  </body>
+</html>

--- a/templates/nunjucks-template/index.njk
+++ b/templates/nunjucks-template/index.njk
@@ -1,0 +1,3 @@
+{% extends "layout.njk" %}
+
+{% block content %}<p>{{ text }}</p>{% endblock %}

--- a/test/test-nunjucks.js
+++ b/test/test-nunjucks.js
@@ -18,11 +18,12 @@ test('reply.view with nunjucks engine and custom templates folder', t => {
   fastify.register(require('../index'), {
     engine: {
       nunjucks: nunjucks
-    }
+    },
+    templates: 'templates'
   })
 
   fastify.get('/', (req, reply) => {
-    reply.view('./templates/index.njk', data)
+    reply.view('index.njk', data)
   })
 
   fastify.listen(0, err => {
@@ -36,7 +37,44 @@ test('reply.view with nunjucks engine and custom templates folder', t => {
       t.equal(response.statusCode, 200)
       t.equal(response.headers['content-length'], '' + body.length)
       t.equal(response.headers['content-type'], 'text/html; charset=utf-8')
-      t.equal(nunjucks.render('./templates/index.njk', data), body.toString())
+      t.equal(nunjucks.render('index.njk', data), body.toString())
+      fastify.close()
+    })
+  })
+})
+
+test('reply.view with nunjucks engine and custom templates array of folders', t => {
+  t.plan(6)
+  const fastify = Fastify()
+  const nunjucks = require('nunjucks')
+  const data = { text: 'text' }
+
+  fastify.register(require('../index'), {
+    engine: {
+      nunjucks: nunjucks
+    },
+    templates: [
+      'templates/nunjucks-layout',
+      'templates/nunjucks-template'
+    ]
+  })
+
+  fastify.get('/', (req, reply) => {
+    reply.view('index.njk', data)
+  })
+
+  fastify.listen(0, err => {
+    t.error(err)
+
+    sget({
+      method: 'GET',
+      url: 'http://localhost:' + fastify.server.address().port
+    }, (err, response, body) => {
+      t.error(err)
+      t.equal(response.statusCode, 200)
+      t.equal(response.headers['content-length'], '' + body.length)
+      t.equal(response.headers['content-type'], 'text/html; charset=utf-8')
+      t.equal(nunjucks.render('index.njk', data), body.toString())
       fastify.close()
     })
   })

--- a/test/test.js
+++ b/test/test.js
@@ -410,6 +410,21 @@ test('register callback should throw if layout option provided with wrong engine
   })
 })
 
+test('register callback should throw if templates option provided as array with wrong engine', t => {
+  t.plan(2)
+  const fastify = Fastify()
+
+  fastify.register(require('../index'), {
+    engine: {
+      pug: require('pug')
+    },
+    templates: ['layouts', 'pages']
+  }).ready(err => {
+    t.ok(err instanceof Error)
+    t.equal(err.message, 'Only Nunjucks supports the "templates" option as an array')
+  })
+})
+
 test('plugin is registered with "point-of-view" name', t => {
   t.plan(2)
   const fastify = Fastify()


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

Hello,

Nunjucks allows you to load templates from mulitple paths, a feature I need as I will be rendering views local to the project, but they will be utilising shared components from an npm module. So I've added support in this PR.

Thanks!

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
