### PR TITLE
Support for async rendering with ejs in production mode

### DIFF
--- a/index.js
+++ b/index.js
@@ -366,6 +366,10 @@ function fastifyView (fastify, opts, next) {
         if (!this.getHeader('content-type')) {
           this.header('Content-Type', 'text/html; charset=' + charset)
         }
+        if (globalOptions.async) {
+          toHtml(data).then(html => this.send(html)).catch(err => this.send(err))
+          return
+        }
         this.send(toHtml(data))
         return
       }

--- a/test/test-ejs-async.js
+++ b/test/test-ejs-async.js
@@ -1,3 +1,5 @@
+'use strict'
+
 const t = require('tap')
 const test = t.test
 const sget = require('simple-get').concat
@@ -30,8 +32,45 @@ test('reply.view with ejs engine and async: true', t => {
       t.equal(response.statusCode, 200)
       t.equal(response.headers['content-length'], '' + body.length)
       t.equal(response.headers['content-type'], 'text/html; charset=utf-8')
-      t.equal(await ejs.render(fs.readFileSync('./templates/ejs-async.ejs', 'utf8'), {}, { async: true }), body.toString())
+      const correctResult = await ejs.render(fs.readFileSync('./templates/ejs-async.ejs', 'utf8'), {}, { async: true })
+      t.equal(correctResult, body.toString())
       fastify.close()
     })
+  })
+})
+
+test('reply.view with ejs engine, async: true, and production: true', t => {
+  const numTests = 4
+  t.plan(numTests * 5 + 1)
+  const fastify = Fastify()
+  const ejs = require('ejs')
+
+  fastify.register(require('../index'), {
+    engine: { ejs },
+    production: true,
+    options: { async: true },
+    templates: 'templates'
+  })
+
+  fastify.get('/', (req, reply) => {
+    reply.view('ejs-async.ejs')
+  })
+
+  fastify.listen({ port: 0 }, err => {
+    t.error(err)
+
+    for (let i = 0; i < numTests; i++) {
+      sget({
+        method: 'GET',
+        url: 'http://localhost:' + fastify.server.address().port
+      }, async (err, response, body) => {
+        t.error(err)
+        t.equal(response.statusCode, 200)
+        t.equal(response.headers['content-length'], '' + body.length)
+        t.equal(response.headers['content-type'], 'text/html; charset=utf-8')
+        t.equal(await ejs.render(fs.readFileSync('./templates/ejs-async.ejs', 'utf8'), {}, { async: true }), body.toString())
+        if (i === numTests - 1) fastify.close()
+      })
+    }
   })
 })

--- a/test/test-ejs-async.js
+++ b/test/test-ejs-async.js
@@ -6,7 +6,7 @@ const sget = require('simple-get').concat
 const Fastify = require('fastify')
 const fs = require('fs')
 
-test('reply.view with ejs engine and async: true', t => {
+test('reply.view with ejs engine and async: true (global option)', t => {
   t.plan(6)
   const fastify = Fastify()
   const ejs = require('ejs')
@@ -32,15 +32,14 @@ test('reply.view with ejs engine and async: true', t => {
       t.equal(response.statusCode, 200)
       t.equal(response.headers['content-length'], '' + body.length)
       t.equal(response.headers['content-type'], 'text/html; charset=utf-8')
-      const correctResult = await ejs.render(fs.readFileSync('./templates/ejs-async.ejs', 'utf8'), {}, { async: true })
-      t.equal(correctResult, body.toString())
+      t.equal(await ejs.render(fs.readFileSync('./templates/ejs-async.ejs', 'utf8'), {}, { async: true }), body.toString())
       fastify.close()
     })
   })
 })
 
-test('reply.view with ejs engine, async: true, and production: true', t => {
-  const numTests = 4
+test('reply.view with ejs engine, async: true (global option), and production: true', t => {
+  const numTests = 2
   t.plan(numTests * 5 + 1)
   const fastify = Fastify()
   const ejs = require('ejs')
@@ -56,20 +55,23 @@ test('reply.view with ejs engine, async: true, and production: true', t => {
     reply.view('ejs-async.ejs')
   })
 
-  fastify.listen({ port: 0 }, err => {
+  fastify.listen({ port: 0 }, async err => {
     t.error(err)
 
     for (let i = 0; i < numTests; i++) {
-      sget({
-        method: 'GET',
-        url: 'http://localhost:' + fastify.server.address().port
-      }, async (err, response, body) => {
-        t.error(err)
-        t.equal(response.statusCode, 200)
-        t.equal(response.headers['content-length'], '' + body.length)
-        t.equal(response.headers['content-type'], 'text/html; charset=utf-8')
-        t.equal(await ejs.render(fs.readFileSync('./templates/ejs-async.ejs', 'utf8'), {}, { async: true }), body.toString())
-        if (i === numTests - 1) fastify.close()
+      await new Promise((resolve, reject) => {
+        sget({
+          method: 'GET',
+          url: 'http://localhost:' + fastify.server.address().port
+        }, async (err, response, body) => {
+          t.error(err)
+          t.equal(response.statusCode, 200)
+          t.equal(response.headers['content-length'], '' + body.length)
+          t.equal(response.headers['content-type'], 'text/html; charset=utf-8')
+          t.equal(await ejs.render(fs.readFileSync('./templates/ejs-async.ejs', 'utf8'), {}, { async: true }), body.toString())
+          if (i === numTests - 1) fastify.close()
+          resolve()
+        })
       })
     }
   })


### PR DESCRIPTION
#314 did not fully cover async rendering with ejs: when caching is applied (in production mode), the error from #312 reappears.
The reason for that is **await** being applied to the asynchronous template only in **readCallback** which is not called if the template has already been compiled and saved to the cache.
This pull request fixes the issue by also awaiting the template after it is retrieved from the cache.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
