### PR TITLE
EJS: Fixed local override of async from true to false

### DIFF
--- a/index.js
+++ b/index.js
@@ -279,7 +279,7 @@ function fastifyView (fastify, opts, next) {
       } catch (error) {
         cachedPage = error
       }
-      if (type === 'ejs' && (globalOptions.async || localOptions?.async)) {
+      if (type === 'ejs' && (localOptions.async)) {
         cachedPage.then(html => {
           if (useHtmlMinification(globalOptions, requestedPath)) {
             html = globalOptions.useHtmlMinifier.minify(html, globalOptions.htmlMinifierOptions || {})
@@ -376,7 +376,7 @@ function fastifyView (fastify, opts, next) {
         if (!this.getHeader('content-type')) {
           this.header('Content-Type', 'text/html; charset=' + charset)
         }
-        if (globalOptions.async || opts?.async) {
+        if (opts?.async !== undefined ? opts.async : globalOptions.async) {
           toHtml(data).then(html => {
             if (useHtmlMinification(globalOptions, requestedPath)) {
               this.send(globalOptions.useHtmlMinifier.minify(html, globalOptions.htmlMinifierOptions || {}))

--- a/index.js
+++ b/index.js
@@ -376,7 +376,7 @@ function fastifyView (fastify, opts, next) {
         if (!this.getHeader('content-type')) {
           this.header('Content-Type', 'text/html; charset=' + charset)
         }
-        if (opts?.async !== undefined ? opts.async : globalOptions.async) {
+        if (opts?.async ?? globalOptions.async) {
           toHtml(data).then(html => {
             if (useHtmlMinification(globalOptions, requestedPath)) {
               this.send(globalOptions.useHtmlMinifier.minify(html, globalOptions.htmlMinifierOptions || {}))

--- a/index.js
+++ b/index.js
@@ -279,7 +279,7 @@ function fastifyView (fastify, opts, next) {
       } catch (error) {
         cachedPage = error
       }
-      if (type === 'ejs' && (localOptions.async)) {
+      if (type === 'ejs' && (localOptions.async ?? globalOptions.async)) {
         cachedPage.then(html => {
           if (useHtmlMinification(globalOptions, requestedPath)) {
             html = globalOptions.useHtmlMinifier.minify(html, globalOptions.htmlMinifierOptions || {})


### PR DESCRIPTION
There has been an error overriding async from true to false in the render function. These changes should fix that.
Now it is possible to specify async: true in global options, and async: false as a local option. The overriding behavior now works correctly: local option async: false will be used.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
