### PR TITLE
remove references to useHtmlMinifyStream

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,27 +217,6 @@ const minifierOpts = {
   }
 ```
 
-To utilize [`html-minify-stream`](https://www.npmjs.com/package/html-minify-stream) in the rendering process with template engines that support streams,
-you can add the option `useHtmlMinifyStream` with a reference to `html-minify-stream`, and the optional `htmlMinifierOptions` option is used to specify the options just like `html-minifier`:
-
-```js
-// get a reference to html-minify-stream
-const htmlMinifyStream = require('html-minify-stream')
-// optionally defined the html-minifier options that are used by html-minify-stream
-const minifierOpts = {
-  removeComments: true,
-  removeCommentsFromCDATA: true,
-  collapseWhitespace: true,
-  collapseBooleanAttributes: true,
-  removeAttributeQuotes: true,
-  removeEmptyAttributes: true
-}
-// in template engine options configure the use of html-minify-stream
-  options: {
-    useHtmlMinifyStream: htmlMinifyStream,
-    htmlMinifierOptions: minifierOpts
-  }
-```
 To filter some paths from minification, you can add the option `pathsToExcludeHtmlMinifier` with list of paths
 ```js
 // get a reference to html-minifier

--- a/package.json
+++ b/package.json
@@ -49,7 +49,6 @@
     "fastify": "^4.0.0-rc.2",
     "handlebars": "^4.7.6",
     "html-minifier": "^4.0.0",
-    "html-minify-stream": "^2.0.0",
     "liquidjs": "^9.15.1",
     "mustache": "^4.0.1",
     "nunjucks": "^3.2.1",


### PR DESCRIPTION
When we dropped the support for marko, the only relevant place where we used useHtmlMinifyStream was gone. This PR removes the documentation of this not anymore existing option.

Also removes html-minify-stream as devDependency as it was probably used for marko tests...
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [ ] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
