### PR TITLE
chore: replace use of deprecated fastify.request.context

### DIFF
--- a/index.js
+++ b/index.js
@@ -167,7 +167,7 @@ function fastifyView (fastify, opts, next) {
   }
 
   function getRequestedPath (fastify) {
-    return (fastify && fastify.request) ? fastify.request.context.config.url : null
+    return (fastify && fastify.request) ? fastify.request.routerPath : null
   }
   // Gets template as string (or precompiled for Handlebars)
   // from LRU cache or filesystem.


### PR DESCRIPTION
Following the deprecation warning on fastify: https://github.com/fastify/fastify/blob/7ffefaf272e1b0da5c0889e0c7c54ac8203756f2/lib/request.js#L159 changed it to use `fastify.request.routerPath`
#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
