### PR TITLE
Allow custom `Content-Type` header for Nunjucks

### DIFF
--- a/index.js
+++ b/index.js
@@ -457,7 +457,9 @@ function fastifyView (fastify, opts, next) {
       if (useHtmlMinification(globalOptions, requestedPath)) {
         html = globalOptions.useHtmlMinifier.minify(html, globalOptions.htmlMinifierOptions || {})
       }
-      this.header('Content-Type', 'text/html; charset=' + charset)
+      if (!this.getHeader('content-type')) {
+        this.header('Content-Type', 'text/html; charset=' + charset)
+      }
       this.send(html)
     })
   }

--- a/test/test-nunjucks.js
+++ b/test/test-nunjucks.js
@@ -304,6 +304,40 @@ test('reply.view for nunjucks engine with data-parameter and reply.locals and de
   })
 })
 
+test('reply.view with nunjucks engine, will preserve content-type', t => {
+  t.plan(6)
+  const fastify = Fastify()
+  const nunjucks = require('nunjucks')
+  const data = { text: 'text' }
+
+  fastify.register(require('../index'), {
+    engine: {
+      nunjucks
+    }
+  })
+
+  fastify.get('/', (req, reply) => {
+    reply.header('Content-Type', 'text/xml')
+    reply.view('./templates/index.njk', data)
+  })
+
+  fastify.listen({ port: 0 }, err => {
+    t.error(err)
+
+    sget({
+      method: 'GET',
+      url: 'http://localhost:' + fastify.server.address().port
+    }, (err, response, body) => {
+      t.error(err)
+      t.equal(response.statusCode, 200)
+      t.equal(response.headers['content-length'], '' + body.length)
+      t.equal(response.headers['content-type'], 'text/xml')
+      t.equal(nunjucks.render('./templates/index.njk', data), body.toString())
+      fastify.close()
+    })
+  })
+})
+
 test('reply.view with nunjucks engine and full path templates folder', t => {
   t.plan(6)
   const fastify = Fastify()


### PR DESCRIPTION
It allows custom `Content-Type` response header for Nunjucks template engine.

Closes #353

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
