### PR TITLE
Type of templates property in PointOfViewOptions show allow arrays

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -33,7 +33,7 @@ declare namespace fastifyView {
       liquid?: any;
       dot?: any;
     };
-    templates?: string;
+    templates?: string | string[];
     includeViewExtension?: boolean;
     options?: object;
     charset?: string;

--- a/types/index.test-d.ts
+++ b/types/index.test-d.ts
@@ -69,3 +69,25 @@ expectType<Promise<string>>(app.view("/index", {}, { layout: "/layout-ts"}))
 expectAssignable<FastifyViewOptions>({ engine: { twig: require('twig') }, propertyName: 'mobile' })
 
 expectDeprecated({} as PointOfViewOptions)
+
+const nunjucksApp = fastify()
+
+nunjucksApp.register(fastifyView, {
+  engine: {
+    nunjucks: require('nunjucks'),
+  },
+  templates: [
+    'templates/nunjucks-layout',
+    'templates/nunjucks-template'
+  ],
+})
+
+nunjucksApp.get('/', (request, reply) => {
+  reply.view('index.njk', { text: 'Sample data' })
+})
+
+expectType<Promise<string>>(nunjucksApp.view('/', { text: 'Hello world' }))
+
+expectAssignable<FastifyViewOptions>({ engine: { nunjucks: require('nunjucks') }, templates: 'templates' })
+
+expectAssignable<FastifyViewOptions>({ engine: { nunjucks: require('nunjucks') }, templates: ['templates/nunjucks-layout', 'templates/nunjucks-template']})


### PR DESCRIPTION
#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
