### PR TITLE
refactor: set nunjucks environment globals on load not per request

### DIFF
--- a/index.js
+++ b/index.js
@@ -50,6 +50,17 @@ function fastifyView (fastify, opts, next) {
     }
   }
 
+  function setupNunjucksEnv (_engine) {
+    if (type === 'nunjucks') {
+      const env = _engine.configure(templatesDir, globalOptions)
+      if (typeof globalOptions.onConfigure === 'function') {
+        globalOptions.onConfigure(env)
+      }
+      return env
+    }
+    return null
+  }
+
   try {
     templatesDirIsValid(templatesDir)
 
@@ -62,7 +73,7 @@ function fastifyView (fastify, opts, next) {
   }
 
   const dotRender = type === 'dot' ? viewDot.call(fastify, preProcessDot.call(fastify, templatesDir, globalOptions)) : null
-  const nunjucksEnv = type === 'nunjucks' ? engine.configure(templatesDir, globalOptions) : null
+  const nunjucksEnv = setupNunjucksEnv(engine)
 
   const renders = {
     ejs: withLayout(viewEjs, globalLayoutFileName),
@@ -444,9 +455,6 @@ function fastifyView (fastify, opts, next) {
     if (!page) {
       this.send(new Error('Missing page'))
       return
-    }
-    if (typeof globalOptions.onConfigure === 'function') {
-      globalOptions.onConfigure(nunjucksEnv)
     }
     data = Object.assign({}, defaultCtx, this.locals, data)
     // Append view extension.


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

The options callback for setting globals/filters on the nunjucks environment was being executed on request setting the same globals/filters over and over again. I've moved the code up to only execute on plugin load.

Don't think any new tests are needed.

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
