### PR TITLE
Fix hbs with layout not throwing errors correctly

### DIFF
--- a/index.js
+++ b/index.js
@@ -732,7 +732,8 @@ function fastifyView (fastify, opts, next) {
           header: () => { },
           send: (result) => {
             if (result instanceof Error) {
-              throw result
+              that.send(result)
+              return
             }
 
             data = Object.assign((data || {}), { body: result })

--- a/test/test-handlebars.js
+++ b/test/test-handlebars.js
@@ -413,6 +413,34 @@ test('reply.view with handlebars engine catches render error', t => {
   })
 })
 
+test('reply.view with handlebars engine and layout catches render error', t => {
+  t.plan(3)
+  const fastify = Fastify()
+  const handlebars = require('handlebars')
+
+  handlebars.registerHelper('badHelper', () => { throw new Error('kaboom') })
+
+  fastify.register(require('../index'), {
+    engine: {
+      handlebars
+    },
+    layout: './templates/layout.hbs'
+  })
+
+  fastify.get('/', (req, reply) => {
+    reply.view('./templates/error.hbs')
+  })
+
+  fastify.inject({
+    method: 'GET',
+    url: '/'
+  }, (err, res) => {
+    t.error(err)
+    t.equal(JSON.parse(res.body).message, 'kaboom')
+    t.equal(res.statusCode, 500)
+  })
+})
+
 test('reply.view with handlebars engine and defaultContext', t => {
   t.plan(6)
   const fastify = Fastify()


### PR DESCRIPTION
In #147, changes were made to get Handlebars to throw errors correctly, with a test. However, in the case where Handlebars was used with a global layout provided, things were still broken. The withLayout helper threw an error directly in the middle of callback code. This PR provides a test demonstrating the failure along with the fix of that mistake.

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
