### PR TITLE
Feature/migrate html minifier terser

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,13 +196,13 @@ Properties from `reply.locals` will override those from `defaultContext`, but no
 
 ## Minifying HTML on render
 
-To utilize [`html-minifier`](https://www.npmjs.com/package/html-minifier) in the rendering process, you can add the option `useHtmlMinifier` with a reference to `html-minifier`,
-and the optional `htmlMinifierOptions` option is used to specify the `html-minifier` options:
+To utilize [`html-minifier-terser`](https://www.npmjs.com/package/html-minifier-terser) in the rendering process, you can add the option `useHtmlMinifier` with a reference to `html-minifier-terser`,
+and the optional `htmlMinifierOptions` option is used to specify the `html-minifier-terser` options:
 
 ```js
-// get a reference to html-minifier
-const minifier = require('html-minifier')
-// optionally defined the html-minifier options
+// get a reference to html-minifier-terser
+const minifier = require('html-minifier-terser')
+// optionally defined the html-minifier-terser options
 const minifierOpts = {
   removeComments: true,
   removeCommentsFromCDATA: true,
@@ -220,9 +220,9 @@ const minifierOpts = {
 
 To filter some paths from minification, you can add the option `pathsToExcludeHtmlMinifier` with list of paths
 ```js
-// get a reference to html-minifier
-const minifier = require('html-minifier')
-// in options configure the use of html-minifier and set paths to exclude from minification
+// get a reference to html-minifier-terser
+const minifier = require('html-minifier-terser')
+// in options configure the use of html-minifier-terser and set paths to exclude from minification
 const options = {
   useHtmlMinifier: minifier,
   pathsToExcludeHtmlMinifier: ['/test']

--- a/benchmark/fastify-ejs-minify.js
+++ b/benchmark/fastify-ejs-minify.js
@@ -4,7 +4,7 @@ require('./setup.js')({
   engine: { ejs: require('ejs') },
   route: (req, reply) => { reply.view('index.ejs', { text: 'text' }) },
   options: {
-    useHtmlMinifier: require('html-minifier'),
+    useHtmlMinifier: require('html-minifier-terser'),
     htmlMinifierOptions: {
       removeComments: true,
       removeCommentsFromCDATA: true,

--- a/index.js
+++ b/index.js
@@ -130,7 +130,7 @@ async function fastifyView (fastify, opts) {
       }
 
       if (minify && !isPathExcludedMinification(this)) {
-        this.send(minify(result, globalOptions.htmlMinifierOptions))
+        this.send(await minify(result, globalOptions.htmlMinifierOptions))
       } else {
         this.send(result)
       }

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "express": "^4.17.1",
     "fastify": "^4.0.0-rc.2",
     "handlebars": "^4.7.6",
-    "html-minifier": "^4.0.0",
+    "html-minifier-terser": "^7.2.0",
     "liquidjs": "^10.0.0",
     "mustache": "^4.0.1",
     "nunjucks": "^3.2.1",

--- a/test/helper.js
+++ b/test/helper.js
@@ -2,7 +2,7 @@
 
 const POV = require('..')
 const Fastify = require('fastify')
-const minifier = require('html-minifier')
+const minifier = require('html-minifier-terser')
 const fs = require('node:fs')
 const dot = require('dot')
 const handlebars = require('handlebars')
@@ -26,7 +26,7 @@ module.exports.dotHtmlMinifierTests = function (t, compileOptions, withMinifierO
   const test = t.test
   const options = withMinifierOptions ? minifierOpts : {}
 
-  test('reply.view with dot engine and html-minifier', t => {
+  test('reply.view with dot engine and html-minifier-terser', t => {
     t.plan(6)
     const fastify = Fastify()
     dot.log = false
@@ -52,17 +52,17 @@ module.exports.dotHtmlMinifierTests = function (t, compileOptions, withMinifierO
       sget({
         method: 'GET',
         url: 'http://localhost:' + fastify.server.address().port
-      }, (err, response, body) => {
+      }, async (err, response, body) => {
         t.error(err)
         t.equal(response.statusCode, 200)
         t.equal(response.headers['content-length'], String(body.length))
         t.equal(response.headers['content-type'], 'text/html; charset=utf-8')
-        t.equal(minifier.minify(dot.process(compileOptions).testdot(data), options), body.toString())
+        t.equal(await minifier.minify(dot.process(compileOptions).testdot(data), options), body.toString())
         fastify.close()
       })
     })
   })
-  test('reply.view with dot engine and paths excluded from html-minifier', t => {
+  test('reply.view with dot engine and paths excluded from html-minifier-terser', t => {
     t.plan(6)
     const fastify = Fastify()
     dot.log = false
@@ -108,7 +108,7 @@ module.exports.etaHtmlMinifierTests = function (t, withMinifierOptions) {
   const test = t.test
   const options = withMinifierOptions ? minifierOpts : {}
 
-  test('reply.view with eta engine and html-minifier', t => {
+  test('reply.view with eta engine and html-minifier-terser', t => {
     t.plan(6)
     const fastify = Fastify()
 
@@ -132,18 +132,18 @@ module.exports.etaHtmlMinifierTests = function (t, withMinifierOptions) {
       sget({
         method: 'GET',
         url: 'http://localhost:' + fastify.server.address().port
-      }, (err, response, body) => {
+      }, async (err, response, body) => {
         t.error(err)
         t.equal(response.statusCode, 200)
         t.equal(response.headers['content-length'], String(body.length))
         t.equal(response.headers['content-type'], 'text/html; charset=utf-8')
-        t.equal(minifier.minify(eta.renderString(fs.readFileSync('./templates/index.eta', 'utf8'), data), options), body.toString())
+        t.equal(await minifier.minify(eta.renderString(fs.readFileSync('./templates/index.eta', 'utf8'), data), options), body.toString())
         fastify.close()
       })
     })
   })
 
-  test('reply.view with eta engine and async and html-minifier', t => {
+  test('reply.view with eta engine and async and html-minifier-terser', t => {
     t.plan(6)
     const fastify = Fastify()
 
@@ -168,17 +168,17 @@ module.exports.etaHtmlMinifierTests = function (t, withMinifierOptions) {
       sget({
         method: 'GET',
         url: 'http://localhost:' + fastify.server.address().port
-      }, (err, response, body) => {
+      }, async (err, response, body) => {
         t.error(err)
         t.equal(response.statusCode, 200)
         t.equal(response.headers['content-length'], String(body.length))
         t.equal(response.headers['content-type'], 'text/html; charset=utf-8')
-        t.equal(minifier.minify(eta.renderString(fs.readFileSync('./templates/index.eta', 'utf8'), data), options), body.toString())
+        t.equal(await minifier.minify(eta.renderString(fs.readFileSync('./templates/index.eta', 'utf8'), data), options), body.toString())
         fastify.close()
       })
     })
   })
-  test('reply.view with eta engine and paths excluded from html-minifier', t => {
+  test('reply.view with eta engine and paths excluded from html-minifier-terser', t => {
     t.plan(6)
     const fastify = Fastify()
 
@@ -219,7 +219,7 @@ module.exports.handleBarsHtmlMinifierTests = function (t, withMinifierOptions) {
   const test = t.test
   const options = withMinifierOptions ? minifierOpts : {}
 
-  test('fastify.view with handlebars engine and html-minifier', t => {
+  test('fastify.view with handlebars engine and html-minifier-terser', t => {
     t.plan(2)
     const fastify = Fastify()
 
@@ -237,8 +237,8 @@ module.exports.handleBarsHtmlMinifierTests = function (t, withMinifierOptions) {
     fastify.ready(err => {
       t.error(err)
 
-      fastify.view('./templates/index.html', data).then(compiled => {
-        t.equal(minifier.minify(handlebars.compile(fs.readFileSync('./templates/index.html', 'utf8'))(data), options), compiled)
+      fastify.view('./templates/index.html', data).then(async compiled => {
+        t.equal(await minifier.minify(handlebars.compile(fs.readFileSync('./templates/index.html', 'utf8'))(data), options), compiled)
         fastify.close()
       })
     })
@@ -249,7 +249,7 @@ module.exports.liquidHtmlMinifierTests = function (t, withMinifierOptions) {
   const test = t.test
   const options = withMinifierOptions ? minifierOpts : {}
 
-  test('reply.view with liquid engine and html-minifier', t => {
+  test('reply.view with liquid engine and html-minifier-terser', t => {
     t.plan(7)
     const fastify = Fastify()
     const engine = new Liquid()
@@ -280,15 +280,15 @@ module.exports.liquidHtmlMinifierTests = function (t, withMinifierOptions) {
         t.equal(response.headers['content-length'], String(body.length))
         t.equal(response.headers['content-type'], 'text/html; charset=utf-8')
         engine.renderFile('./templates/index.liquid', data)
-          .then((html) => {
+          .then(async (html) => {
             t.error(err)
-            t.equal(minifier.minify(html, options), body.toString())
+            t.equal(await minifier.minify(html, options), body.toString())
           })
         fastify.close()
       })
     })
   })
-  test('reply.view with liquid engine and paths excluded from html-minifier', t => {
+  test('reply.view with liquid engine and paths excluded from html-minifier-terser', t => {
     t.plan(7)
     const fastify = Fastify()
     const engine = new Liquid()
@@ -334,7 +334,7 @@ module.exports.nunjucksHtmlMinifierTests = function (t, withMinifierOptions) {
   const test = t.test
   const options = withMinifierOptions ? minifierOpts : {}
 
-  test('reply.view with nunjucks engine, full path templates folder, and html-minifier', t => {
+  test('reply.view with nunjucks engine, full path templates folder, and html-minifier-terser', t => {
     t.plan(6)
     const fastify = Fastify()
 
@@ -359,18 +359,18 @@ module.exports.nunjucksHtmlMinifierTests = function (t, withMinifierOptions) {
       sget({
         method: 'GET',
         url: 'http://localhost:' + fastify.server.address().port
-      }, (err, response, body) => {
+      }, async (err, response, body) => {
         t.error(err)
         t.equal(response.statusCode, 200)
         t.equal(response.headers['content-length'], String(body.length))
         t.equal(response.headers['content-type'], 'text/html; charset=utf-8')
         // Global Nunjucks templates dir changed here.
-        t.equal(minifier.minify(nunjucks.render('./index.njk', data), options), body.toString())
+        t.equal(await minifier.minify(nunjucks.render('./index.njk', data), options), body.toString())
         fastify.close()
       })
     })
   })
-  test('reply.view with nunjucks engine, full path templates folder, and paths excluded from html-minifier', t => {
+  test('reply.view with nunjucks engine, full path templates folder, and paths excluded from html-minifier-terser', t => {
     t.plan(6)
     const fastify = Fastify()
 
@@ -413,7 +413,7 @@ module.exports.pugHtmlMinifierTests = function (t, withMinifierOptions) {
   const test = t.test
   const options = withMinifierOptions ? minifierOpts : {}
 
-  test('reply.view with pug engine and html-minifier', t => {
+  test('reply.view with pug engine and html-minifier-terser', t => {
     t.plan(6)
     const fastify = Fastify()
 
@@ -437,17 +437,17 @@ module.exports.pugHtmlMinifierTests = function (t, withMinifierOptions) {
       sget({
         method: 'GET',
         url: 'http://localhost:' + fastify.server.address().port
-      }, (err, response, body) => {
+      }, async (err, response, body) => {
         t.error(err)
         t.equal(response.statusCode, 200)
         t.equal(response.headers['content-length'], String(body.length))
         t.equal(response.headers['content-type'], 'text/html; charset=utf-8')
-        t.equal(minifier.minify(pug.render(fs.readFileSync('./templates/index.pug', 'utf8'), data), options), body.toString())
+        t.equal(await minifier.minify(pug.render(fs.readFileSync('./templates/index.pug', 'utf8'), data), options), body.toString())
         fastify.close()
       })
     })
   })
-  test('reply.view with pug engine and paths excluded from html-minifier', t => {
+  test('reply.view with pug engine and paths excluded from html-minifier-terser', t => {
     t.plan(6)
     const fastify = Fastify()
 
@@ -488,7 +488,7 @@ module.exports.twigHtmlMinifierTests = function (t, withMinifierOptions) {
   const test = t.test
   const options = withMinifierOptions ? minifierOpts : {}
 
-  test('reply.view with twig engine and html-minifier', t => {
+  test('reply.view with twig engine and html-minifier-terser', t => {
     t.plan(7)
     const fastify = Fastify()
 
@@ -517,15 +517,15 @@ module.exports.twigHtmlMinifierTests = function (t, withMinifierOptions) {
         t.equal(response.statusCode, 200)
         t.equal(response.headers['content-length'], String(body.length))
         t.equal(response.headers['content-type'], 'text/html; charset=utf-8')
-        Twig.renderFile('./templates/index.twig', data, (err, html) => {
+        Twig.renderFile('./templates/index.twig', data, async (err, html) => {
           t.error(err)
-          t.equal(minifier.minify(html, options), body.toString())
+          t.equal(await minifier.minify(html, options), body.toString())
         })
         fastify.close()
       })
     })
   })
-  test('reply.view with twig engine and paths excluded from html-minifier', t => {
+  test('reply.view with twig engine and paths excluded from html-minifier-terser', t => {
     t.plan(7)
     const fastify = Fastify()
 

--- a/test/test-ejs-async.js
+++ b/test/test-ejs-async.js
@@ -5,6 +5,7 @@ const test = t.test
 const sget = require('simple-get').concat
 const Fastify = require('fastify')
 const fs = require('node:fs')
+const minifier = require('html-minifier-terser')
 
 test('reply.view with ejs engine and async: true (global option)', t => {
   t.plan(6)
@@ -77,9 +78,8 @@ test('reply.view with ejs engine, async: true (global option), and production: t
   })
 })
 
-const minifier = require('html-minifier')
 const minifierOpts = { collapseWhitespace: true }
-test('reply.view with ejs engine, async: true (global option), and html-minifier', t => {
+test('reply.view with ejs engine, async: true (global option), and html-minifier-terser', t => {
   t.plan(6)
   const fastify = Fastify()
   const ejs = require('ejs')
@@ -109,7 +109,7 @@ test('reply.view with ejs engine, async: true (global option), and html-minifier
       t.equal(response.statusCode, 200)
       t.equal(response.headers['content-length'], '' + body.length)
       t.equal(response.headers['content-type'], 'text/html; charset=utf-8')
-      t.equal(minifier.minify(await ejs.render(fs.readFileSync('./templates/ejs-async.ejs', 'utf8'), {}, { async: true }), minifierOpts), body.toString())
+      t.equal(await minifier.minify(await ejs.render(fs.readFileSync('./templates/ejs-async.ejs', 'utf8'), {}, { async: true }), minifierOpts), body.toString())
       fastify.close()
     })
   })
@@ -144,7 +144,7 @@ test('reply.view with ejs engine, async: true (global option), and html-minifier
       t.equal(response.statusCode, 200)
       t.equal(response.headers['content-length'], '' + body.length)
       t.equal(response.headers['content-type'], 'text/html; charset=utf-8')
-      t.equal(minifier.minify(await ejs.render(fs.readFileSync('./templates/ejs-async.ejs', 'utf8'), {}, { async: true })), body.toString())
+      t.equal(await minifier.minify(await ejs.render(fs.readFileSync('./templates/ejs-async.ejs', 'utf8'), {}, { async: true })), body.toString())
       fastify.close()
     })
   })
@@ -184,7 +184,7 @@ test('reply.view with ejs engine, async: true (global option), and html-minifier
           t.equal(response.statusCode, 200)
           t.equal(response.headers['content-length'], '' + body.length)
           t.equal(response.headers['content-type'], 'text/html; charset=utf-8')
-          t.equal(minifier.minify(await ejs.render(fs.readFileSync('./templates/ejs-async.ejs', 'utf8'), {}, { async: true }), minifierOpts), body.toString())
+          t.equal(await minifier.minify(await ejs.render(fs.readFileSync('./templates/ejs-async.ejs', 'utf8'), {}, { async: true }), minifierOpts), body.toString())
           if (i === numTests - 1) fastify.close()
           resolve()
         })
@@ -262,7 +262,7 @@ test('reply.view with ejs engine, async: true (local option), and production: tr
   })
 })
 
-test('reply.view with ejs engine, async: true (local override), and html-minifier', t => {
+test('reply.view with ejs engine, async: true (local override), and html-minifier-terser', t => {
   t.plan(6)
   const fastify = Fastify()
   const ejs = require('ejs')
@@ -292,13 +292,13 @@ test('reply.view with ejs engine, async: true (local override), and html-minifie
       t.equal(response.statusCode, 200)
       t.equal(response.headers['content-length'], '' + body.length)
       t.equal(response.headers['content-type'], 'text/html; charset=utf-8')
-      t.equal(minifier.minify(await ejs.render(fs.readFileSync('./templates/ejs-async.ejs', 'utf8'), { }, { async: true }), minifierOpts), body.toString())
+      t.equal(await minifier.minify(await ejs.render(fs.readFileSync('./templates/ejs-async.ejs', 'utf8'), { }, { async: true }), minifierOpts), body.toString())
       fastify.close()
     })
   })
 })
 
-test('reply.view with ejs engine, async: false (local override), and html-minifier', t => {
+test('reply.view with ejs engine, async: false (local override), and html-minifier-terser', t => {
   t.plan(6)
   const fastify = Fastify()
   const ejs = require('ejs')
@@ -328,13 +328,13 @@ test('reply.view with ejs engine, async: false (local override), and html-minifi
       t.equal(response.statusCode, 200)
       t.equal(response.headers['content-length'], '' + body.length)
       t.equal(response.headers['content-type'], 'text/html; charset=utf-8')
-      t.equal(minifier.minify(await ejs.render(fs.readFileSync('./templates/index.ejs', 'utf8'), { text: 'text' }, { async: false }), minifierOpts), body.toString())
+      t.equal(await minifier.minify(await ejs.render(fs.readFileSync('./templates/index.ejs', 'utf8'), { text: 'text' }, { async: false }), minifierOpts), body.toString())
       fastify.close()
     })
   })
 })
 
-test('reply.view with ejs engine, async: true (local override), and html-minifier in production mode', t => {
+test('reply.view with ejs engine, async: true (local override), and html-minifier-terser in production mode', t => {
   const numTests = 3
   t.plan(numTests * 5 + 1)
   const fastify = Fastify()
@@ -368,7 +368,7 @@ test('reply.view with ejs engine, async: true (local override), and html-minifie
           t.equal(response.statusCode, 200)
           t.equal(response.headers['content-length'], '' + body.length)
           t.equal(response.headers['content-type'], 'text/html; charset=utf-8')
-          t.equal(minifier.minify(await ejs.render(fs.readFileSync('./templates/ejs-async.ejs', 'utf8'), {}, { async: true }), minifierOpts), body.toString())
+          t.equal(await minifier.minify(await ejs.render(fs.readFileSync('./templates/ejs-async.ejs', 'utf8'), {}, { async: true }), minifierOpts), body.toString())
           if (i === numTests - 1) fastify.close()
           resolve()
         })
@@ -377,7 +377,7 @@ test('reply.view with ejs engine, async: true (local override), and html-minifie
   })
 })
 
-test('reply.view with ejs engine, async: false (local override), and html-minifier in production mode', t => {
+test('reply.view with ejs engine, async: false (local override), and html-minifier-terser in production mode', t => {
   const numTests = 2
   t.plan(numTests * 5 + 1)
   const fastify = Fastify()
@@ -411,7 +411,7 @@ test('reply.view with ejs engine, async: false (local override), and html-minifi
           t.equal(response.statusCode, 200)
           t.equal(response.headers['content-length'], '' + body.length)
           t.equal(response.headers['content-type'], 'text/html; charset=utf-8')
-          t.equal(minifier.minify(await ejs.render(fs.readFileSync('./templates/index.ejs', 'utf8'), { text: 'text' }, { async: false }), minifierOpts), body.toString())
+          t.equal(await minifier.minify(await ejs.render(fs.readFileSync('./templates/index.ejs', 'utf8'), { text: 'text' }, { async: false }), minifierOpts), body.toString())
           if (i === numTests - 1) fastify.close()
           resolve()
         })

--- a/test/test-ejs.js
+++ b/test/test-ejs.js
@@ -6,7 +6,7 @@ const sget = require('simple-get').concat
 const Fastify = require('fastify')
 const fs = require('node:fs')
 const path = require('node:path')
-const minifier = require('html-minifier')
+const minifier = require('html-minifier-terser')
 const minifierOpts = {
   removeComments: true,
   removeCommentsFromCDATA: true,
@@ -545,7 +545,7 @@ test('reply.view with ejs engine and defaultContext', t => {
   })
 })
 
-test('reply.view with ejs engine and html-minifier', t => {
+test('reply.view with ejs engine and html-minifier-terser', t => {
   t.plan(6)
   const fastify = Fastify()
   const ejs = require('ejs')
@@ -571,17 +571,17 @@ test('reply.view with ejs engine and html-minifier', t => {
     sget({
       method: 'GET',
       url: 'http://localhost:' + fastify.server.address().port
-    }, (err, response, body) => {
+    }, async (err, response, body) => {
       t.error(err)
       t.equal(response.statusCode, 200)
       t.equal(response.headers['content-length'], '' + body.length)
       t.equal(response.headers['content-type'], 'text/html; charset=utf-8')
-      t.equal(minifier.minify(ejs.render(fs.readFileSync('./templates/index.ejs', 'utf8'), data), minifierOpts), body.toString())
+      t.equal(await minifier.minify(ejs.render(fs.readFileSync('./templates/index.ejs', 'utf8'), data), minifierOpts), body.toString())
       fastify.close()
     })
   })
 })
-test('reply.view with ejs engine and paths excluded from html-minifier', t => {
+test('reply.view with ejs engine and paths excluded from html-minifier-terser', t => {
   t.plan(6)
   const fastify = Fastify()
   const ejs = require('ejs')
@@ -618,7 +618,7 @@ test('reply.view with ejs engine and paths excluded from html-minifier', t => {
     })
   })
 })
-test('reply.view with ejs engine and html-minifier in production mode', t => {
+test('reply.view with ejs engine and html-minifier-terser in production mode', t => {
   const numTests = 5
   t.plan(numTests * 5 + 1)
   const fastify = Fastify()
@@ -651,7 +651,7 @@ test('reply.view with ejs engine and html-minifier in production mode', t => {
           t.equal(response.statusCode, 200)
           t.equal(response.headers['content-length'], '' + body.length)
           t.equal(response.headers['content-type'], 'text/html; charset=utf-8')
-          t.equal(minifier.minify(ejs.render(fs.readFileSync('./templates/index.ejs', 'utf8'), data), minifierOpts), body.toString())
+          t.equal(await minifier.minify(ejs.render(fs.readFileSync('./templates/index.ejs', 'utf8'), data), minifierOpts), body.toString())
           if (i === numTests - 1) fastify.close()
           resolve()
         })

--- a/test/test-mustache.js
+++ b/test/test-mustache.js
@@ -5,7 +5,7 @@ const test = t.test
 const sget = require('simple-get').concat
 const Fastify = require('fastify')
 const fs = require('node:fs')
-const minifier = require('html-minifier')
+const minifier = require('html-minifier-terser')
 const proxyquire = require('proxyquire')
 const minifierOpts = {
   removeComments: true,
@@ -433,7 +433,7 @@ test('reply.view with mustache engine with partials in production mode should ca
   })
 })
 
-test('reply.view with mustache engine with partials and html-minifier', t => {
+test('reply.view with mustache engine with partials and html-minifier-terser', t => {
   t.plan(6)
   const fastify = Fastify()
   const mustache = require('mustache')
@@ -458,18 +458,18 @@ test('reply.view with mustache engine with partials and html-minifier', t => {
     sget({
       method: 'GET',
       url: 'http://localhost:' + fastify.server.address().port
-    }, (err, response, replyBody) => {
+    }, async (err, response, replyBody) => {
       t.error(err)
       t.equal(response.statusCode, 200)
       t.equal(response.headers['content-length'], '' + replyBody.length)
       t.equal(response.headers['content-type'], 'text/html; charset=utf-8')
-      t.equal(minifier.minify(mustache.render(fs.readFileSync('./templates/index.mustache', 'utf8'), data, { body: '<p>{{ text }}</p>' }), minifierOpts), replyBody.toString())
+      t.equal(await minifier.minify(mustache.render(fs.readFileSync('./templates/index.mustache', 'utf8'), data, { body: '<p>{{ text }}</p>' }), minifierOpts), replyBody.toString())
       fastify.close()
     })
   })
 })
 
-test('reply.view with mustache engine with partials and paths excluded from html-minifier', t => {
+test('reply.view with mustache engine with partials and paths excluded from html-minifier-terser', t => {
   t.plan(6)
   const fastify = Fastify()
   const mustache = require('mustache')


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)

### Goal
I saw an issue of an user that ask support for **html-minifier-terser in place of html-minifier.**
Only thing that change is that minify method is a promise.

### Behavior using old html-minifier
Since in js we can do
```js
function syncMethod(){
   return "hello";
}
const output = await syncMethod()
```
Even point-of-view will add the terser version which is Promise based, configuring options like this:
```js
const minifier = require('html-minifier')
// optionally defined the html-minifier options
const minifierOpts = {
  removeComments: true,
}
  options: {
    useHtmlMinifier: minifier,
    htmlMinifierOptions: minifierOpts
  }
```

can be done also using **html-minifier** instead **html-minifier-terser**
