### PR TITLE
refactor(index): destruct module imports

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,14 +1,8 @@
 'use strict'
 
 const fp = require('fastify-plugin')
-const readFile = require('node:fs').readFile
-const accessSync = require('node:fs').accessSync
-const existsSync = require('node:fs').existsSync
-const mkdirSync = require('node:fs').mkdirSync
-const readdirSync = require('node:fs').readdirSync
-const resolve = require('node:path').resolve
-const join = require('node:path').join
-const { basename, dirname, extname } = require('node:path')
+const { accessSync, existsSync, mkdirSync, readdirSync, readFile } = require('node:fs')
+const { basename, dirname, extname, join, resolve } = require('node:path')
 const HLRU = require('hashlru')
 const supportedEngines = ['ejs', 'nunjucks', 'pug', 'handlebars', 'mustache', 'art-template', 'twig', 'liquid', 'dot', 'eta']
 


### PR DESCRIPTION
Import functions all in one go rather than successive `require()` calls.
Probably the tiniest perf improvement but cba to bench for a quectosecond improvement.

Saves a few bytes regardless.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
