### PR TITLE
add parse raw template in view

### DIFF
--- a/.taprc
+++ b/.taprc
@@ -3,7 +3,6 @@ jsx: false
 flow: false
 coverage: true
 nyc-arg: [--exclude=out]
-check-coverage: false
 
 files:
   - test/**/*.js

--- a/test/test-ejs.js
+++ b/test/test-ejs.js
@@ -1134,3 +1134,69 @@ test('fastify.view with ejs engine and callback in production mode', t => {
     })
   })
 })
+
+test('reply.view with ejs engine and raw template', t => {
+  t.plan(6)
+  const fastify = Fastify()
+  const ejs = require('ejs')
+  const data = { text: 'text' }
+
+  fastify.register(require('../index'), {
+    engine: {
+      ejs
+    }
+  })
+
+  fastify.get('/', (req, reply) => {
+    reply.view({ raw: fs.readFileSync('./templates/index.ejs', 'utf8') }, data)
+  })
+
+  fastify.listen({ port: 0 }, err => {
+    t.error(err)
+
+    sget({
+      method: 'GET',
+      url: 'http://localhost:' + fastify.server.address().port
+    }, (err, response, body) => {
+      t.error(err)
+      t.equal(response.statusCode, 200)
+      t.equal(response.headers['content-length'], '' + body.length)
+      t.equal(response.headers['content-type'], 'text/html; charset=utf-8')
+      t.equal(ejs.render(fs.readFileSync('./templates/index.ejs', 'utf8'), data), body.toString())
+      fastify.close()
+    })
+  })
+})
+
+test('reply.view with ejs engine and function template', t => {
+  t.plan(6)
+  const fastify = Fastify()
+  const ejs = require('ejs')
+  const data = { text: 'text' }
+
+  fastify.register(require('../index'), {
+    engine: {
+      ejs
+    }
+  })
+
+  fastify.get('/', (req, reply) => {
+    reply.view(ejs.compile(fs.readFileSync('./templates/index.ejs', 'utf8')), data)
+  })
+
+  fastify.listen({ port: 0 }, err => {
+    t.error(err)
+
+    sget({
+      method: 'GET',
+      url: 'http://localhost:' + fastify.server.address().port
+    }, (err, response, body) => {
+      t.error(err)
+      t.equal(response.statusCode, 200)
+      t.equal(response.headers['content-length'], '' + body.length)
+      t.equal(response.headers['content-type'], 'text/html; charset=utf-8')
+      t.equal(ejs.render(fs.readFileSync('./templates/index.ejs', 'utf8'), data), body.toString())
+      fastify.close()
+    })
+  })
+})

--- a/test/test-mustache.js
+++ b/test/test-mustache.js
@@ -721,3 +721,101 @@ test('fastify.view with mustache engine, should throw page missing', t => {
     })
   })
 })
+test('reply.view for mustache and raw template', t => {
+  t.plan(6)
+  const fastify = Fastify()
+  const mustache = require('mustache')
+  const data = { text: 'text' }
+
+  fastify.register(require('../index'), {
+    engine: {
+      mustache
+    },
+    defaultContext: data
+  })
+
+  fastify.get('/', (req, reply) => {
+    reply.view({ raw: fs.readFileSync('./templates/index.html', 'utf8') })
+  })
+
+  fastify.listen({ port: 0 }, err => {
+    t.error(err)
+
+    sget({
+      method: 'GET',
+      url: 'http://localhost:' + fastify.server.address().port
+    }, (err, response, body) => {
+      t.error(err)
+      t.equal(response.statusCode, 200)
+      t.equal(response.headers['content-length'], '' + body.length)
+      t.equal(response.headers['content-type'], 'text/html; charset=utf-8')
+      t.equal(mustache.render(fs.readFileSync('./templates/index.html', 'utf8'), data), body.toString())
+      fastify.close()
+    })
+  })
+})
+
+test('reply.view for mustache and function template', t => {
+  t.plan(6)
+  const fastify = Fastify()
+  const mustache = require('mustache')
+  const data = { text: 'text' }
+
+  fastify.register(require('../index'), {
+    engine: {
+      mustache
+    },
+    defaultContext: data
+  })
+
+  fastify.get('/', (req, reply) => {
+    reply.header('Content-Type', 'text/html').view((mustache.render.bind(mustache, fs.readFileSync('./templates/index.html', 'utf8'))))
+  })
+
+  fastify.listen({ port: 0 }, err => {
+    t.error(err)
+
+    sget({
+      method: 'GET',
+      url: 'http://localhost:' + fastify.server.address().port
+    }, (err, response, body) => {
+      t.error(err)
+      t.equal(response.statusCode, 200)
+      t.equal(response.headers['content-length'], '' + body.length)
+      t.equal(response.headers['content-type'], 'text/html')
+      t.equal(mustache.render(fs.readFileSync('./templates/index.html', 'utf8'), data), body.toString())
+      fastify.close()
+    })
+  })
+})
+
+// test('reply.view for mustache and unknown template type', t => {
+//   t.plan(3)
+//   const fastify = Fastify()
+//   const mustache = require('mustache')
+//   const data = { text: 'text' }
+
+//   fastify.register(require('../index'), {
+//     engine: {
+//       mustache
+//     },
+//     defaultContext: data
+//   })
+
+//   fastify.get('/', (req, reply) => {
+//     reply.view({ })
+//   })
+
+//   fastify.listen({ port: 0 }, err => {
+//     t.error(err)
+
+//     sget({
+//       method: 'GET',
+//       url: 'http://localhost:' + fastify.server.address().port
+//     }, (err, response, body) => {
+//       t.error(err)
+//       t.equal(response.statusCode, 500)
+//       fastify.close()
+//     })
+//   })
+// })

--- a/test/test-pug.js
+++ b/test/test-pug.js
@@ -498,3 +498,69 @@ test('reply.view with pug engine should return 500 if compile fails', t => {
     })
   })
 })
+
+test('reply.view with pug engine and raw template', t => {
+  t.plan(6)
+  const fastify = Fastify()
+  const pug = require('pug')
+  const data = { text: 'text' }
+
+  fastify.register(require('../index'), {
+    engine: {
+      pug
+    }
+  })
+
+  fastify.get('/', (req, reply) => {
+    reply.view({ raw: fs.readFileSync('./templates/index.pug', 'utf8') }, data)
+  })
+
+  fastify.listen({ port: 0 }, err => {
+    t.error(err)
+
+    sget({
+      method: 'GET',
+      url: 'http://localhost:' + fastify.server.address().port
+    }, (err, response, body) => {
+      t.error(err)
+      t.equal(response.statusCode, 200)
+      t.equal(response.headers['content-length'], '' + body.length)
+      t.equal(response.headers['content-type'], 'text/html; charset=utf-8')
+      t.equal(pug.render(fs.readFileSync('./templates/index.pug', 'utf8'), data), body.toString())
+      fastify.close()
+    })
+  })
+})
+
+test('reply.view with pug engine and function template', t => {
+  t.plan(6)
+  const fastify = Fastify()
+  const pug = require('pug')
+  const data = { text: 'text' }
+
+  fastify.register(require('../index'), {
+    engine: {
+      pug
+    }
+  })
+
+  fastify.get('/', (req, reply) => {
+    reply.view(pug.compile(fs.readFileSync('./templates/index.pug', 'utf8')), data)
+  })
+
+  fastify.listen({ port: 0 }, err => {
+    t.error(err)
+
+    sget({
+      method: 'GET',
+      url: 'http://localhost:' + fastify.server.address().port
+    }, (err, response, body) => {
+      t.error(err)
+      t.equal(response.statusCode, 200)
+      t.equal(response.headers['content-length'], '' + body.length)
+      t.equal(response.headers['content-type'], 'text/html; charset=utf-8')
+      t.equal(pug.render(fs.readFileSync('./templates/index.pug', 'utf8'), data), body.toString())
+      fastify.close()
+    })
+  })
+})


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->
Fixes: https://github.com/fastify/point-of-view/issues/390
```js
fastify.get('/', async (req, reply) => {
    const rawTemplate = await someRequestOrQuery(req)
    const someData = await getSomeData(req)
    reply.view({ raw: rawTemplate }, someData)
})
```

```js
fastify.get('/', async (req, reply) => {
    const rawTemplate = await prepareHbsTemplate(req)
    const template = hbs.template(rawTemplate) // typeof template === 'function'
    const someData = await getSomeData(req)
    reply.view(template, someData, { layout: someLayout })
})
```

#### Checklist

- [X] run `npm run test` and `npm run benchmark`
- [X] tests and/or benchmarks are included
- [ ] documentation is changed or added (soon)
- [X] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
