### PR TITLE
chore: add benchmark PR workflow

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,0 +1,30 @@
+name: Benchmark PR
+
+on:
+  pull_request_target:
+    types: 
+      - labeled
+
+jobs:
+  benchmark:
+    if: ${{ github.event.label.name == 'benchmark' }}
+    uses: fastify/workflows/.github/workflows/plugins-benchmark-pr.yml@main
+    with:
+      npm-script: benchmark
+
+  remove-label:
+    if: "always()"
+    needs: 
+      - benchmark
+    runs-on: ubuntu-latest
+    steps:
+      - name: Remove benchmark label
+        uses: octokit/request-action@v2.x
+        id: remove-label
+        with:
+          route: DELETE /repos/{repo}/issues/{issue_number}/labels/{name}
+          repo: ${{ github.event.pull_request.head.repo.full_name }}
+          issue_number: ${{ github.event.pull_request.number }}
+          name: benchmark
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Adds the shared `plugins-benchmark-pr.yml` workflow to PRs.

### Usage
Add the `benchmark` tag to a PR in order to run benchmarks and compare against `master`.

### Example
https://github.com/mweberxyz/point-of-view/pull/2

#### Checklist
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
