### PR TITLE
perf: cache layout access check

### DIFF
--- a/index.js
+++ b/index.js
@@ -645,13 +645,23 @@ async function fastifyView (fastify, opts) {
   }
 
   function hasAccessToLayoutFile (fileName, ext) {
+    const layoutKey = `layout-${fileName}-${ext}`
+    let result = fastify[viewCache].get(layoutKey)
+
+    if (typeof result === 'boolean') {
+      return result
+    }
+
     try {
       accessSync(join(templatesDir, getPage(fileName, ext)))
-
-      return true
+      result = true
     } catch (e) {
-      return false
+      result = false
     }
+
+    fastify[viewCache].set(layoutKey, result)
+
+    return result
   }
 }
 

--- a/test/test-handlebars.js
+++ b/test/test-handlebars.js
@@ -331,7 +331,7 @@ test('fastify.view with handlebars engine with layout option on render', t => {
 })
 
 test('fastify.view with handlebars engine with invalid layout option on render should throw', t => {
-  t.plan(3)
+  t.plan(5)
 
   const fastify = Fastify()
   const handlebars = require('handlebars')
@@ -345,6 +345,11 @@ test('fastify.view with handlebars engine with invalid layout option on render s
 
   fastify.ready(err => {
     t.error(err)
+    fastify.view('./templates/index-for-layout.hbs', data, { layout: './templates/invalid-layout.hbs' }, (err, compiled) => {
+      t.ok(err instanceof Error)
+      t.equal(err.message, 'unable to access template "./templates/invalid-layout.hbs"')
+    })
+    // repeated for test coverage of layout access check lru
     fastify.view('./templates/index-for-layout.hbs', data, { layout: './templates/invalid-layout.hbs' }, (err, compiled) => {
       t.ok(err instanceof Error)
       t.equal(err.message, 'unable to access template "./templates/invalid-layout.hbs"')


### PR DESCRIPTION
Specifying a layout on render causes a synchronous `fs.accessSync` on every request. Cache the result of these lookups in LRU to avoid duplicate blocking checks.

### Benchmarks (master)
```
fastify-ejs-local-layout.js: 84885.34 req/s
fastify-ejs-global-layout.js: 115680 req/s
```

### Benchmarks (PR)
```
fastify-ejs-local-layout.js: 114592 req/s
fastify-ejs-global-layout.js: 116917.34 req/s
```

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
