### PR TITLE
refactor: encapsulate cache as decorator

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,7 +20,7 @@ const fastifyViewCache = fp(
 )
 
 async function fastifyView (fastify, opts) {
-  if (typeof fastify[viewCache] === 'undefined') {
+  if (fastify[viewCache] === undefined) {
     await fastify.register(fastifyViewCache, opts)
   }
   if (!opts.engine) {

--- a/package.json
+++ b/package.json
@@ -60,7 +60,6 @@
     "mustache": "^4.0.1",
     "nunjucks": "^3.2.1",
     "pino": "^8.0.0",
-    "proxyquire": "^2.1.3",
     "pug": "^3.0.0",
     "simple-get": "^4.0.0",
     "split2": "^4.0.0",

--- a/test/test-mustache.js
+++ b/test/test-mustache.js
@@ -6,7 +6,6 @@ const sget = require('simple-get').concat
 const Fastify = require('fastify')
 const fs = require('node:fs')
 const minifier = require('html-minifier-terser')
-const proxyquire = require('proxyquire')
 const minifierOpts = {
   removeComments: true,
   removeCommentsFromCDATA: true,
@@ -345,15 +344,13 @@ test('reply.view with mustache engine with partials in production mode should us
   const fastify = Fastify()
   const mustache = require('mustache')
   const data = { text: 'text' }
-  const POV = proxyquire('..', {
-    hashlru: function () {
-      return {
-        get: () => {
-          return '<div>Cached Response</div>'
-        },
-        set: () => { }
-      }
-    }
+  const POV = require('..')
+
+  fastify.decorate(POV.fastifyViewCache, {
+    get: () => {
+      return '<div>Cached Response</div>'
+    },
+    set: () => { }
   })
 
   fastify.register(POV, {

--- a/test/test-pug.js
+++ b/test/test-pug.js
@@ -5,7 +5,6 @@ const test = t.test
 const sget = require('simple-get').concat
 const Fastify = require('fastify')
 const fs = require('node:fs')
-const proxyquire = require('proxyquire')
 
 require('./helper').pugHtmlMinifierTests(t, true)
 require('./helper').pugHtmlMinifierTests(t, false)
@@ -47,15 +46,13 @@ test('reply.view with pug engine in production mode should use cache', t => {
   t.plan(6)
   const fastify = Fastify()
   const pug = require('pug')
-  const POV = proxyquire('..', {
-    hashlru: function () {
-      return {
-        get: () => {
-          return () => '<div>Cached Response</div>'
-        },
-        set: () => { }
-      }
-    }
+  const POV = require('..')
+
+  fastify.decorate(POV.fastifyViewCache, {
+    get: () => {
+      return () => '<div>Cached Response</div>'
+    },
+    set: () => { }
   })
 
   fastify.register(POV, {

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -53,6 +53,7 @@ declare namespace fastifyView {
 
   export const fastifyView: FastifyView
   export { fastifyView as default }
+  export const fastifyViewCache: Symbol
 }
 
 declare function fastifyView(...params: Parameters<FastifyView>): ReturnType<FastifyView>


### PR DESCRIPTION
In preparation for potentially migrating from `hashlru` to `toad-cache` -- encapsulate the lru as a decorator.

This will:
- make the tests agnostic to underlying cache implementations
- aid in benchmarking differences between cache implementations
- drop a devDependency

## Benchmarks
 |Benchmark||Node 18 PR|Node 18 Base||Node 20 PR|Node 20 Base||Node 21 PR|Node 21 Base|
|-|-|-|-|-|-|-|-|-|-|
|express.js||8351|8231||8815|8591||8439|8447|
|fastify.js||42975|41247||43391|42687||42271|42463|
|fastify-art.js||9511|9431||10487|**11567**||9287|9271|
|fastify-dot.js||47199|46367||47615|46751||47839|46975|
|fastify-eta.js||27199|27007||30095|29327||**37695**|35327|
|fastify-pug.js||45183|45759||46367|44735||46719|46559|
|fastify-twig.js||30175|**35423**||38911|38335||40831|39167|
|fastify-liquid.js||**7531**|6323||7663|7667||7803|7711|
|fastify-mustache.js||31855|31503||34079|35423||33887|33951|
|fastify-nunjucks.js||41599|41631||42655|43167||43295|42463|
|fastify-ejs-async.js||35039|35647||43263|44095||45247|43327|
|fastify-ejs-minify.js||11855|**12567**||14463|**15383**||13823|14407|
|fastify-handlebars.js||25231|25647||31055|31727||26495|27679|
|fastify-ejs-local-layout.js||26831|26159||31487|31583||31039|31167|
|fastify-ejs-global-layout.js||**34527**|32479||34975|**40543**||40159|41375|

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
