### PR TITLE
chore: swap toad cache for hashlru

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,14 +3,14 @@ const { readFile } = require('node:fs/promises')
 const fp = require('fastify-plugin')
 const { accessSync, existsSync, mkdirSync, readdirSync } = require('node:fs')
 const { basename, dirname, extname, join, resolve } = require('node:path')
-const HLRU = require('hashlru')
+const { LruMap } = require('toad-cache')
 const supportedEngines = ['ejs', 'nunjucks', 'pug', 'handlebars', 'mustache', 'art-template', 'twig', 'liquid', 'dot', 'eta']
 
 const viewCache = Symbol('@fastify/view/cache')
 
 const fastifyViewCache = fp(
   async function cachePlugin (fastify, opts) {
-    const lru = HLRU(opts?.maxCache || 100)
+    const lru = new LruMap(opts.maxCache || 100)
     fastify.decorate(viewCache, lru)
   },
   {

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   "homepage": "https://github.com/fastify/point-of-view#readme",
   "dependencies": {
     "fastify-plugin": "^4.0.0",
-    "hashlru": "^2.3.0"
+    "toad-cache": "^3.7.0"
   },
   "devDependencies": {
     "@fastify/pre-commit": "^2.0.2",


### PR DESCRIPTION
Swap in `toad-cache` for `hashlru` as requested here: https://github.com/fastify/point-of-view/pull/414#issuecomment-1965962275

## Benchmarks
|Benchmark||Node 18 PR|Node 18 Base||Node 20 PR|Node 20 Base||Node 21 PR|Node 21 Base|
|-|-|-|-|-|-|-|-|-|-|
|express.js||8943|8871||**9423**|8799||9183|9151|
|fastify.js||35263|**42847**||45151|44095||43007|42079|
|fastify-art.js||10167|9711||11671|12007||9431|9023|
|fastify-dot.js||49887|48895||48639|48671||47039|47487|
|fastify-eta.js||27999|28111||29983|30767||37151|35647|
|fastify-pug.js||42079|**46751**||49055|48127||35647|**46271**|
|fastify-twig.js||32015|**36639**||40063|40095||33631|**37759**|
|fastify-liquid.js||6975|6975||7363|**8335**||7611|7583|
|fastify-mustache.js||33535|32799||34943|34751||33855|34303|
|fastify-nunjucks.js||42751|42911||45759|43935||41663|42399|
|fastify-ejs-async.js||35967|36223||43007|**46431**||41855|**44191**|
|fastify-ejs-minify.js||12303|**12991**||15407|14983||14391|14263|
|fastify-handlebars.js||26863|27135||32799|31839||26543|**29423**|
|fastify-ejs-local-layout.js||28559|**32031**||34079|32591||32191|33151|
|fastify-ejs-global-layout.js||34303|**41119**||41887|40927||40543|40799|



#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
