### PR TITLE
suggestion: await engine to support inline engine import in options

### DIFF
--- a/.taprc
+++ b/.taprc
@@ -5,4 +5,4 @@ coverage: true
 nyc-arg: [--exclude=out]
 
 files:
-  - test/**/*.js
+  - test/**/*.{js,mjs}

--- a/index.js
+++ b/index.js
@@ -32,7 +32,7 @@ async function fastifyView (fastify, opts) {
   }
   const charset = opts.charset || 'utf-8'
   const propertyName = opts.propertyName || 'view'
-  const engine = opts.engine[type]
+  const engine = await opts.engine[type]
   const globalOptions = opts.options || {}
   const templatesDir = resolveTemplateDir(opts)
   const includeViewExtension = opts.includeViewExtension || false

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "lint": "standard",
     "test-with-snapshot": "cross-env TAP_SNAPSHOT=1 tap test/test-ejs-with-snapshot.js",
     "test": "npm run test:unit && npm run test:typescript",
-    "test:unit": "tap",
+    "test:unit": "tap test/*.js test/*.mjs",
     "test:typescript": "tsd"
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "lint": "standard",
     "test-with-snapshot": "cross-env TAP_SNAPSHOT=1 tap test/test-ejs-with-snapshot.js",
     "test": "npm run test:unit && npm run test:typescript",
-    "test:unit": "tap test/*.js test/*.mjs",
+    "test:unit": "tap",
     "test:typescript": "tsd"
   },
   "repository": {

--- a/test/test-import-engine.mjs
+++ b/test/test-import-engine.mjs
@@ -1,0 +1,34 @@
+import t from 'tap'
+import get from 'simple-get'
+import Fastify from 'fastify'
+import fs from 'node:fs'
+const test = t.test
+const sget = get.concat
+
+console.log('running import test')
+
+test('using an imported engine as a promise', t => {
+  t.plan(3)
+  const fastify = Fastify()
+  const data = { text: 'text' }
+  const ejs = import('ejs')
+
+  fastify.register(import('../index.js'), { engine: { ejs }, templates: 'templates' })
+
+  fastify.get('/', (req, reply) => {
+    reply.view('index.ejs', data)
+  })
+
+  fastify.listen({ port: 0 }, err => {
+    t.error(err)
+
+    sget({
+      method: 'GET',
+      url: 'http://localhost:' + fastify.server.address().port
+    }, async (err, response, body) => {
+      t.error(err)
+      t.equal((await ejs).render(fs.readFileSync('./templates/index.ejs', 'utf8'), data), body.toString())
+      fastify.close()
+    })
+  })
+})

--- a/test/test-import-engine.mjs
+++ b/test/test-import-engine.mjs
@@ -5,8 +5,6 @@ import fs from 'node:fs'
 const test = t.test
 const sget = get.concat
 
-console.log('running import test')
-
 test('using an imported engine as a promise', t => {
   t.plan(3)
   const fastify = Fastify()


### PR DESCRIPTION
With commonjs it was common to require the engine in the options, and the current readme suggests this usage:

```js
fastify.register(require("@fastify/view"), {  engine: { ejs: require("ejs") } });
```

With modules, the same usage wasn't previously possible, because the inline import returns a promise.

```mjs
app.register(import('@fastify/view'), { engine: { ejs: import('ejs') } })
// results in error later that "engine.compile is not a function"
```

So instead you had to await that import inline, and delay setting up further plugins:
```mjs
app.register(import('@fastify/view'), { engine: { ejs: await import('ejs') } })
```

Since the plugin initialisation is already an async function, it seemed straightforward to just `await` the engine during plugin initialisation instead, which will hopefully allow more plugin loading to occur before blocking on the await.

Is this a good idea? If so I will update the docs as well.

If not we could add validation that the engine is actually an engine (has a .compile function?), to catch this error at plugin initialisation time?


<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [-] tests and/or benchmarks are included
- [-] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
