### PR TITLE
fix: stop duplication of path in template dir

### DIFF
--- a/index.js
+++ b/index.js
@@ -412,7 +412,7 @@ async function fastifyView (fastify, opts) {
     function render (filename, data) {
       let render
       if (typeof filename === 'string') {
-        confs.filename = join(templatesDir, filename)
+        confs.filename = filename
         render = engine.compile(confs)
       } else if (typeof filename === 'function') {
         render = filename

--- a/test/test-art-template.js
+++ b/test/test-art-template.js
@@ -44,6 +44,43 @@ test('reply.view with art-template engine and custom templates folder', t => {
   })
 })
 
+test('reply.view with art-template engine and explicit root folder', t => {
+  t.plan(6)
+  const fastify = Fastify()
+  const art = require('art-template')
+  const data = { text: 'text' }
+
+  fastify.register(require('../index'), {
+    engine: {
+      'art-template': art
+    },
+    root: 'templates'
+  })
+
+  fastify.get('/', (req, reply) => {
+    reply.view('./index.art', data)
+  })
+
+  fastify.listen({ port: 10086 }, err => {
+    t.error(err)
+
+    sget({
+      method: 'GET',
+      url: 'http://127.0.0.1:10086/'
+    }, (err, response, body) => {
+      t.error(err)
+      t.equal(response.statusCode, 200)
+      t.equal(response.headers['content-length'], '' + body.length)
+      t.equal(response.headers['content-type'], 'text/html; charset=utf-8')
+
+      const templatePath = path.join(__dirname, '..', 'templates', 'index.art')
+
+      t.equal(art(templatePath, data), body.toString())
+      fastify.close()
+    })
+  })
+})
+
 test('reply.view for art-template without data-parameter and defaultContext', t => {
   t.plan(6)
   const fastify = Fastify()


### PR DESCRIPTION
Closes #437

When the `root` option is passed explicitly and the `art-template` engine is in use, the `root` value is being duplicated in the resolved template directory.

This leads to an error like this: notice how `templates` is present twice in the path.

```
-{"statusCode":500,"error":"Internal Server Error","message":"template not found:
'/home/rich/point-of-view/templates/templates/index.art'"}
```

The fix is to remove this duplication. The `resolveTemplateDir` function already uses any `root` option (if present) so there's no need to consider it again.

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
