### PR TITLE
types: use `node:` prefix for builtins

### DIFF
--- a/types/index-global-layout.test-d.ts
+++ b/types/index-global-layout.test-d.ts
@@ -1,7 +1,7 @@
 import fastify from 'fastify'
 import fastifyView, { FastifyViewOptions } from '..'
 import { expectAssignable } from 'tsd'
-import * as path from 'path'
+import * as path from 'node:path'
 
 interface Locals {
   appVersion: string,

--- a/types/index.test-d.ts
+++ b/types/index.test-d.ts
@@ -1,7 +1,7 @@
 import fastify from 'fastify'
 import fastifyView, { PointOfViewOptions, FastifyViewOptions } from '..'
 import { expectAssignable, expectNotAssignable, expectDeprecated, expectType } from 'tsd'
-import * as path from 'path'
+import * as path from 'node:path'
 
 interface Locals {
   appVersion: string,


### PR DESCRIPTION
See https://github.com/fastify/fastify/pull/5896. This is a batch PR, so may have some issues. Please review changes.