### PR TITLE
test(test): limit file permissions

### DIFF
--- a/test/test.js
+++ b/test/test.js
@@ -46,7 +46,7 @@ test('fastify.view.clearCache clears cache', async t => {
   try {
     fs.mkdirSync(templatesFolder)
   } catch {}
-  fs.writeFileSync(path.join(templatesFolder, 'cache_clear_test.ejs'), '<html><body><span>123</span></body></<html>')
+  fs.writeFileSync(path.join(templatesFolder, 'cache_clear_test.ejs'), '<html><body><span>123</span></body></<html>', { mode: 0o600 })
   const fastify = Fastify()
 
   fastify.register(require('../index'), {
@@ -70,7 +70,7 @@ test('fastify.view.clearCache clears cache', async t => {
 
   t.assert.strictEqual(result.headers.get('content-length'), '' + responseContent.length)
   t.assert.strictEqual(result.headers.get('content-type'), 'text/html; charset=utf-8')
-  fs.writeFileSync(path.join(templatesFolder, 'cache_clear_test.ejs'), '<html><body><span>456</span></body></<html>')
+  fs.writeFileSync(path.join(templatesFolder, 'cache_clear_test.ejs'), '<html><body><span>456</span></body></<html>', { mode: 0o600 })
 
   const result2 = await fetch('http://127.0.0.1:' + fastify.server.address().port + '/view-cache-test')
 


### PR DESCRIPTION
Closes https://github.com/fastify/point-of-view/security/code-scanning/43 by setting file permissions to 0600 (read/write for owner only).

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/main/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/main/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/main/CODE_OF_CONDUCT.md)
