### PR TITLE
Revert "chore: remove .taprc"

### DIFF
--- a/.taprc
+++ b/.taprc
@@ -1,0 +1,3 @@
+disable-coverage: true
+files:
+  - test/*.{js,mjs}


### PR DESCRIPTION
Reverts fastify/point-of-view#464

Forgot tap still needed for snapshots. dur.