### PR TITLE
fix: support mustache partials as documented

### DIFF
--- a/index.js
+++ b/index.js
@@ -458,9 +458,10 @@ async function fastifyView (fastify, opts) {
       // append view extension
       page = getPage(page, 'mustache')
     }
+    const partials = Object.assign({}, globalOptions.partials || {}, options.partials || {})
     const requestedPath = getRequestedPath(this)
     const templateString = await getTemplate(page)
-    const partialsObject = await getPartials(page, { partials: options.partials || {}, requestedPath })
+    const partialsObject = await getPartials(page, { partials, requestedPath })
 
     let html
     if (typeof templateString === 'function') {

--- a/templates/index-with-2-partials.mustache
+++ b/templates/index-with-2-partials.mustache
@@ -1,0 +1,8 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head></head>
+  <body>
+    {{> partial1 }}
+    {{> partial2 }}
+  </body>
+</html>


### PR DESCRIPTION
The documentation for Mustache says that we can declare partials in the global `options` parameter, like so:

```
  options: {
    partials: {
      header: 'header.mustache',
      footer: 'footer.mustache'
    }
  }
```

This did not work, because `globalOptions` was not visited when getting the partials. Only partials declared in the `reply.view` call were taken into account:

```js
reply.view('./templates/index.mustache', data, { partials: { header: 'header.mustache' } })
```

This PR aims to add support for the documented usage while retaining support for the existing one, by merging `options` with `globalOptions`.

Since the existing implementation is not documented, and is not supported/consistent with Handlebars' usage, I took the decision not to add it to the documentation, but I'm open to it if needed.

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] ~documentation is changed or added~
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/main/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/main/CODE_OF_CONDUCT.md)
