### PR TITLE
Fix using multiple view instances in production mode

### DIFF
--- a/index.js
+++ b/index.js
@@ -187,6 +187,10 @@ async function fastifyView (fastify, opts) {
     return result
   }
 
+  function getCacheKey (key) {
+    return [propertyName, key].join('|')
+  }
+
   function getDefaultExtension (type) {
     const mappedExtensions = {
       handlebars: 'hbs',
@@ -223,7 +227,7 @@ async function fastifyView (fastify, opts) {
     if (type === 'handlebars') {
       data = engine.compile(data, globalOptions.compileOptions)
     }
-    fastify[viewCache].set(file, data)
+    fastify[viewCache].set(getCacheKey(file), data)
     return data
   }
 
@@ -238,7 +242,7 @@ async function fastifyView (fastify, opts) {
       isRaw = true
       file = file.raw
     }
-    const data = fastify[viewCache].get(file)
+    const data = fastify[viewCache].get(getCacheKey(file))
     if (data && prod) {
       return data
     }
@@ -270,7 +274,7 @@ async function fastifyView (fastify, opts) {
   }
 
   function getPartialsCacheKey (page, partials, requestedPath) {
-    let cacheKey = page
+    let cacheKey = getCacheKey(page)
 
     for (const key of Object.keys(partials)) {
       cacheKey += `|${key}:${partials[key]}`
@@ -295,7 +299,7 @@ async function fastifyView (fastify, opts) {
 
     const compiledPage = engine.compile(html, localOptions)
 
-    fastify[viewCache].set(page, compiledPage)
+    fastify[viewCache].set(getCacheKey(page), compiledPage)
     return compiledPage
   }
 
@@ -345,7 +349,7 @@ async function fastifyView (fastify, opts) {
       // append view extension
       page = getPage(page, type)
     }
-    const toHtml = fastify[viewCache].get(page)
+    const toHtml = fastify[viewCache].get(getCacheKey(page))
 
     if (toHtml && prod) {
       return toHtml(data)
@@ -376,7 +380,7 @@ async function fastifyView (fastify, opts) {
       // append view extension
       page = getPage(page, type)
     }
-    const toHtml = fastify[viewCache].get(page)
+    const toHtml = fastify[viewCache].get(getCacheKey(page))
 
     if (toHtml && prod) {
       return toHtml(data)
@@ -630,7 +634,7 @@ async function fastifyView (fastify, opts) {
   }
 
   function hasAccessToLayoutFile (fileName, ext) {
-    const layoutKey = `layout-${fileName}-${ext}`
+    const layoutKey = getCacheKey(`layout-${fileName}-${ext}`)
     let result = fastify[viewCache].get(layoutKey)
 
     if (typeof result === 'boolean') {

--- a/templates/root-bar/body.hbs
+++ b/templates/root-bar/body.hbs
@@ -1,0 +1,1 @@
+body bar

--- a/templates/root-bar/index.hbs
+++ b/templates/root-bar/index.hbs
@@ -1,0 +1,1 @@
+Index bar {{> body}}

--- a/templates/root-foo/body.hbs
+++ b/templates/root-foo/body.hbs
@@ -1,0 +1,1 @@
+body foo

--- a/templates/root-foo/index.hbs
+++ b/templates/root-foo/index.hbs
@@ -1,0 +1,1 @@
+Index foo {{> body}}


### PR DESCRIPTION
Include the property name in the cache key to avoid clashes when multiple view instances with different settings and root directories are registered.

Signed-off-by: Dagfinn Ilmari Mannsåker <ilmari.mannsaker@zoopla.co.uk>

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/main/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/main/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/main/CODE_OF_CONDUCT.md)
