### PR TITLE
chore: removed types deprecated

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -50,11 +50,6 @@ declare namespace fastifyView {
     asyncPropertyName?: string;
   }
 
-  /**
-   * @deprecated Use FastifyViewOptions
-   */
-  export type PointOfViewOptions = FastifyViewOptions
-
   export const fastifyView: FastifyView
   export { fastifyView as default }
   export const fastifyViewCache: Symbol


### PR DESCRIPTION
Proposal:

- Drop `PointOfViewOptions` type alias that was marked as `@deprecated` in favour of `FastifyViewOptions`.


Note:

- Release a major version of the plugin after this pull request has been merged
- PR reference:
   - https://github.com/fastify/fastify-swagger-ui/pull/274